### PR TITLE
Added error propagation & numerical buffer factors; improved buffesm (bis)

### DIFF
--- a/R/derivnum.R
+++ b/R/derivnum.R
@@ -1,0 +1,411 @@
+# derivnum()
+# This subroutine computes partial derivatives of output carbonate variables 
+# with respect to input variables (two), plus nutrients (two), temperature and salinity
+# and dissociation constants.
+#
+# It uses the central difference method, which consists to : 
+# - introduce a small perturbation delta (plus or minus) in one input
+# - and compute the induced delta in output variables
+#
+# The ratio between delta and input value is chosen so : 
+#    for perturbing input pair :  a constant which depends on the type of input pair of variables.
+#    for perturbing nutrients  :  1.e-6
+#    for perturbing T and S    :  1.e-3
+#
+# Input parameters :
+#   - varid  :  (scalar) identifier of variable with respect to which derivative is requested
+#                = variable length, case insensitive, character code
+#                  case '1' or 'var1'  :  Variable 1 of the input pair (This is TAlk if flag is 15)
+#                  case '2' or 'var2'  :  Variable 2 of the input pair (This is DIC  if flag is 15)
+#                  case 'sil', 'silt', 'tsil' or 'silicate'      : Total silicate concentration
+#                  case 'phos', 'phost', 'tphos' or 'phosphate'  : Total phosphate concentration
+#                  case 't', 'temp' or 'temperature' : temperature
+#                  case 's', 'sal' or 'salinity'     : salinity
+#                  case 'K0','K1','K2','Kb','Kw','Kspa' or 'Kspc' : dissociation constaht
+#
+#   - others     :  same à input of subroutine  carb() : scalar or vectors
+#
+# Returns one set of partial derivatives
+derivnum <- 
+function(varid, flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0, k1k2='l', kf='x', ks="d", 
+         pHscale="T", b="l10", gas="potential")
+{
+    # Input conditionning
+    # -------------------
+    
+    n <- max(length(flag), length(var1), length(var2), length(S), length(T), length(P), length(Pt), length(Sit), length(k1k2), length(kf), length(pHscale), length(ks), length(b))
+    if(length(flag)!=n){flag <- rep(flag[1],n)}
+    if(length(var1)!=n){var1 <- rep(var1[1],n)}
+    if(length(var2)!=n){var2 <- rep(var2[1],n)}
+    if(length(S)!=n){S <- rep(S[1],n)}
+    if(length(T)!=n){T <- rep(T[1],n)}
+    if(length(Patm)!=n){Patm <- rep(Patm[1],n)}
+    if(length(P)!=n){P <- rep(P[1],n)}
+    if(length(Pt)!=n){Pt <- rep(Pt[1],n)}
+    if(length(Sit)!=n){Sit <- rep(Sit[1],n)}
+    if(length(k1k2)!=n){k1k2 <- rep(k1k2[1],n)}
+    if(length(kf)!=n){kf <- rep(kf[1],n)}
+    if(length(ks)!=n){ks <- rep(ks[1],n)}
+    if(length(pHscale)!=n){pHscale <- rep(pHscale[1],n)}
+    if(length(b)!=n){b <- rep(b[1],n)}
+
+    varid <-toupper(varid)
+    
+    # Constants: names of variables, sorted by flag number
+    varnames  = rbind (
+        c("H", "CO2"),            # flag = 1    
+        c("CO2", "HCO3"),         # flag = 2    
+        c("CO2", "CO3"),          # flag = 3    
+        c("CO2", "ALK"),          # flag = 4    
+        c("CO2", "DIC"),          # flag = 5    
+        c("H", "HCO3"),           # flag = 6    
+        c("H", "CO3"),            # flag = 7    
+        c("H", "ALK"),            # flag = 8    
+        c("H", "DIC"),            # flag = 9    
+        c("HCO3", "CO3"),         # flag = 10   
+        c("HCO3", "ALK"),         # flag = 11   
+        c("HCO3", "DIC"),         # flag = 12   
+        c("CO3", "ALK"),          # flag = 13   
+        c("CO3", "DIC"),          # flag = 14   
+        c("ALK", "DIC"),          # flag = 15 
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("pCO2", "H"),           # flag = 21   
+        c("pCO2", "HCO3"),        # flag = 22   
+        c("pCO2", "CO3"),         # flag = 23   
+        c("pCO2", "ALK"),         # flag = 24   
+        c("pCO2", "DIC")          # flag = 25   
+    )
+    var1name <- varnames[flag,1]
+    var2name <- varnames[flag,2]
+    
+    # Relative deltas (perturbations) sorted by flag number
+    # default value is 1.e-3
+    const_deltas = rbind (
+        c(1.e-8, 1.e-3),         # flag = 1    
+        c(1.e-3, 1.e-3),         # flag = 2    
+        c(1.e-3, 1.e-3),         # flag = 3    
+        c(1.e-6, 1.e-6),         # flag = 4    
+        c(1.e-5, 1.e-5),         # flag = 5    
+        c(1.e-8, 1.e-3),         # flag = 6    
+        c(1.e-8, 1.e-3),         # flag = 7    
+        c(1.e-1, 1.e-5),         # flag = 8    
+        c(1.e-1, 1.e-1),         # flag = 9    
+        c(1.e-3, 1.e-3),         # flag = 10   
+        c(1.e-3, 1.e-3),         # flag = 11   
+        c(1.e-3, 1.e-3),         # flag = 12   
+        c(1.e-3, 1.e-3),         # flag = 13   
+        c(1.e-3, 1.e-3),         # flag = 14   
+        c(1.e-6, 1.e-6),         # flag = 15   
+        c(0, 0),
+        c(0, 0),
+        c(0, 0),
+        c(0, 0),
+        c(0, 0),
+        c(1.e-3, 1.e-8),         # flag = 21   
+        c(1.e-3, 1.e-3),         # flag = 22   
+        c(1.e-3, 1.e-3),         # flag = 23   
+        c(1.e-6, 1.e-6),         # flag = 24   
+        c(1.e-5, 1.e-5)          # flag = 25   
+    )
+    
+    # BASELINE:    it is usefull only if one computes RELATIVE derivatives
+    # --------
+    #seacarb <- carb(flag, var1, var2, S=S, T=T, Patm=Patm, P=P, Pt=Pt, Sit=Sit, k1k2=k1k2, kf=kf, ks=ks, pHscale=pHscale, b=b, gas=gas)
+    # H <- 10^(-seacarb$pH)
+    # seacarb <- cbind(H,seacarb)
+
+    # Compute two slightly different values for input
+    # -----------------------------------------------
+
+    # Default values : not perturbed
+    # no change on var1 and var2
+    var11 = var12 = var1
+    var21 = var22 = var2
+    # no change on Sil total and Phos total
+    Sit1 = Sit2 = Sit
+    Pt1  = Pt2  = Pt
+    # no change on T and S
+    T1 = T2 = T
+    S1 = S2 = S
+
+    # Initialise absolute deltas
+    abs_dx <- rep(NA, n)
+
+    # Uppercase names of dissociation constants
+    K_id <- c('K0', 'K1', 'K2', 'KB', 'KW', 'KSPA', 'KSPC')
+    # Flag for dissociation constant as perturbed variable 
+    flag_dissoc_K = varid %in% K_id
+    
+    # if perturbed variable is a dissociation constant
+    if (flag_dissoc_K)
+    {
+        # Approximate values for K0, K1, K2, Kb, Kspa and Kspc
+        # They will be used to compute an absolute perturbation value on these constants
+        K <- c(0.034, 1.2e-06, 8.3e-10, 2.1e-09, 6.1e-14, 6.7e-07, 4.3e-07)
+        # Choose value of absolute perturbation
+        index <- which (K_id == varid)
+        perturbation = K[index] * 1.e-3   # 0.1 percent of Kx value
+        abs_dx = 2 * perturbation
+    }
+    # Var1 is perturbed
+    else if (varid %in% c('1', 'VAR1'))
+    {
+        # Define relative deltas
+        delta = const_deltas[flag, 1]
+
+        # where input variable is [H+] concentration
+        FH = (var1name == 'H')
+        # Change slightly [H+]
+        H_var1 <- 10^(-var1[FH])
+        H1 = H_var1 - H_var1*delta[FH]
+        H2 = H_var1 + H_var1*delta[FH]
+        var11[FH] = -log10(H1)
+        var12[FH] = -log10(H2)
+        abs_dx[FH] = H2 - H1
+
+        # where it is not
+        GH = ! FH
+        # Change slightly var1
+        var11[GH] = var1[GH] - var1[GH]*delta[GH]
+        var12[GH] = var1[GH] + var1[GH]*delta[GH]
+        abs_dx[GH] = var12[GH] - var11[GH]
+    }
+    else if (varid %in% c('2', 'VAR2'))    # var2 (second variable of input pair) is perturbed
+    {
+        # Define relative deltas
+        delta = const_deltas[flag, 2]
+
+        # where second input variable is [H+] concentration
+        FH = (var2name == 'H')
+        # Change slightly H+]
+        H_var2 <- 10^(-var2[FH])
+        H1 = H_var2 - H_var2*delta[FH]
+        H2 = H_var2 + H_var2*delta[FH]
+        var21[FH] = -log10(H1)
+        var22[FH] = -log10(H2)
+        abs_dx[FH] = H2 - H1
+
+        # where it is not
+        GH = ! FH
+        # Change slightly var2
+        var21[GH] = var2[GH] - var2[GH]*delta[GH]
+        var22[GH] = var2[GH] + var2[GH]*delta[GH]
+        abs_dx[GH] = var22[GH] - var21[GH]
+    }
+    else if (varid %in% c('SIL', 'TSIL', 'SILT', 'SILICATE'))    # Sil total
+    {
+        # Define relative delta
+        delta = 1.e-3
+
+        center_value = Sit
+        # Change slightly temperature
+        Sit1 = Sit - Sit*delta
+        Sit2 = Sit + Sit*delta
+        abs_dx = Sit2 - Sit1
+    }
+    else if (varid %in% c('PHOS', 'TPHOS', 'PHOST', 'PHOSPHATE'))    # Phos total
+    {
+        # Define relative delta
+        delta = 1.e-3
+
+        center_value = Pt
+        # Change slightly temperature
+        Pt1 = Pt - Pt*delta
+        Pt2 = Pt + Pt*delta
+        abs_dx = Pt2 - Pt1
+    }
+    else if (varid %in% c('T', 'TEMP', 'TEMPERATURE'))    # Temperature
+    {
+        # Define relative delta
+        delta = 1.e-4
+        
+        center_value = T
+        # Change slightly temperature
+        T1 = T - T*delta
+        T2 = T + T*delta
+        abs_dx = T2 - T1
+    }
+    else if (varid %in% c('S', 'SAL', 'SALINITY'))   # Salinity
+    {
+        # Define relative delta
+        delta = 1.e-4
+
+        center_value = S
+        # Change slightly temperature
+        S1 = S - S*delta
+        S2 = S + S*delta
+        abs_dx = S2 - S1
+    }
+    else
+    {
+        stop ("Invalid input parameter: ", varid)
+    }
+
+    # Define local functions K0, K1, K2, ...
+    # --------------------------------------
+
+    # These function will replace original K0, K1, K2.... functions, at some computation time
+    # They are intended to return slightly modified (perturbed) values of dissociation constants
+    #
+    # Their input (beside their regular parameters):
+    #
+    #   perturbation :  absolute value of (tiny) perturbation
+    #   sign_factor  :  factor -1 or +1 gives the sign or perturbation
+    
+    if (varid == 'K0') 
+    {
+        K0 <- function(S=35,T=25,P=0,Patm=1)
+        {
+            # Call original K0 function
+            out <- seacarb::K0(S, T, P, Patm=Patm)
+            # perturb value of K0
+            out[1] = out[1] + sign_factor * perturbation  # sign_factor is +1 or -1
+            return (out)
+        }
+    }
+    else if (varid == 'K1') 
+    {
+        K1 <-function(S=35,T=25,P=0,k1k2='x',pHscale="T",kSWS2scale=0,ktotal2SWS_P0=0)
+        {
+            # Call original K1 function
+            out <- seacarb::K1(S, T, P, k1k2=k1k2, pHscale=pHscale, kSWS2scale=kSWS2scale, ktotal2SWS_P0=ktotal2SWS_P0)
+            # perturb value of K1
+            out[1] = out[1] + sign_factor * perturbation  # sign_factor is +1 or -1
+            return (out)
+        }
+    }
+    else if (varid == 'K2') 
+    {
+        K2 <- function(S=35,T=25,P=0,k1k2='x',pHscale="T",kSWS2scale=0,ktotal2SWS_P0=0)
+        {
+            # Call original K2 function
+            out <- seacarb::K2(S, T, P, k1k2=k1k2, pHscale=pHscale, kSWS2scale=kSWS2scale, ktotal2SWS_P0=ktotal2SWS_P0)
+            # perturb value of K2
+            out[1] = out[1] + sign_factor * perturbation  # sign_factor is +1 or -1
+            return (out)
+        }
+    }
+    else if (varid == 'KW') 
+    {
+        Kw <- function(S=35,T=25,P=0,pHscale="T",kSWS2scale=0)
+        {
+            # Call original Kw function
+            out <- seacarb::Kw(S, T, P, pHscale=pHscale, kSWS2scale=kSWS2scale)
+            # perturb value of Kw
+            out[1] = out[1] + sign_factor * perturbation  # sign_factor is +1 or -1
+            return (out)
+        }
+    }
+    else if (varid == 'KB')
+    {
+        Kb <- function(S=35,T=25,P=0,pHscale="T",kSWS2scale=0,ktotal2SWS_P0=0)
+        {
+            # Call original Kb function
+            out <- seacarb::Kb(S, T, P, pHscale=pHscale, kSWS2scale=kSWS2scale, ktotal2SWS_P0=ktotal2SWS_P0)
+            # perturb value of Kb
+            out[1] = out[1] + sign_factor * perturbation  # sign_factor is +1 or -1
+            return (out)
+        }
+    }
+    else if (varid == 'KSPA')
+    {
+        Kspa <- function(S=35,T=25,P=0)
+        {
+            # Call original Kspa function
+            out <- seacarb::Kspa(S, T, P)
+            # perturb value of Kspa
+            out[1] = out[1] + sign_factor * perturbation  # sign_factor is +1 or -1
+            return (out)
+        }
+    }
+    else if (varid == 'KSPC')
+    {
+        Kspc <- function(S=35,T=25,P=0)
+        {
+            # Call original Kspc function
+            out <- seacarb::Kspc(S, T, P)
+            # perturb value of Kspa
+            out[1] = out[1] + sign_factor * perturbation  # sign_factor is +1 or -1
+            return (out)
+        }
+    }
+    
+    # PERTURBATION:
+    # -------------
+    
+    # if perturbed variable is a dissociation constant
+    if (flag_dissoc_K)
+    {
+        # Save then change execution environment of function carb()
+        saved_env <- environment(carb)
+        # Using environment(NULL) will hide original seacarb::K0, seacarb::K1, ... function (depending on "varid")
+        environment(carb) <- environment(NULL)
+        # Note :  environment(NULL) is the environment created when the function derivnum() is executed
+        #         It then contains all locally defined functions, like K0, K1, K2, ...
+        #         Then, when carb() is executed and looks for a name (variable or function) that is not a local variable,
+        #         it will look into evironment(NULL), which has been attached to it, 
+        #         before looking into global or seacarb module environment.
+        
+        # Point 1: (one dissociation constant is somewhat smaller)
+        sign_factor = -1.0
+        cdel1 <- carb(flag, var1, var2, S=S, T=T, Patm=Patm, P=P, Pt=Pt, Sit=Sit, k1k2=k1k2, kf=kf, ks=ks, pHscale=pHscale, b=b, gas=gas)
+
+        # Point 2: (one dissociation constant is somewhat bigger)
+        sign_factor = 1.0
+        cdel2 <- carb(flag, var1, var2, S=S, T=T, Patm=Patm, P=P, Pt=Pt, Sit=Sit, k1k2=k1k2, kf=kf, ks=ks, pHscale=pHscale, b=b, gas=gas)
+
+        # Restore environment of carb()
+        environment(carb) <- saved_env
+    }
+    else
+    {
+        # Point 1: (one of var1, var2, T or S is somewhat smaller)
+        cdel1 <- carb(flag, var11, var21, S=S1, T=T1, Patm=Patm, P=P, Pt=Pt1, Sit=Sit1, k1k2=k1k2, kf=kf, ks=ks, pHscale=pHscale, b=b, gas=gas)
+
+        # Point 2: (one of var1, var2, T or S is somewhat bigger)
+        cdel2 <- carb(flag, var12, var22, S=S2, T=T2, Patm=Patm, P=P, Pt=Pt2, Sit=Sit2, k1k2=k1k2, kf=kf, ks=ks, pHscale=pHscale, b=b, gas=gas)
+    }
+    # Compute [H+] concentration and add it to data-frame
+    H <- 10^(-cdel1$pH)
+    cdel1 <- cbind(H,cdel1)
+    H <- 10^(-cdel2$pH)
+    cdel2 <- cbind(H,cdel2)
+
+    # Centered difference
+    dy <-(cdel2 - cdel1)
+
+    # Drop unnecessary columns
+    # ------------------------
+    
+    # list fixed columns to drop
+    drops=c('flag', 'S', 'T', 'P', 'Patm', 'fCO2pot', 'pCO2pot', 'fCO2insitu', 'pCO2insitu')
+    # add input variable 1 to list
+    if (all(var1name == var1name[1]))
+    {
+        drops = c(drops, var1name)
+        # if to drop H, drop also pH
+        if (var1name[1] == 'H')
+            drops = c(drops, 'pH')
+    }
+    # add input variable 2 to list
+    if (all(var2name == var2name[1]))
+    {
+        drops = c(drops, var2name)
+        # if to drop H, drop also pH
+        if (var2name[1] == 'H')
+            drops = c(drops, 'pH')
+    }
+    # Drop columns
+    dy <- dy[,!(names(dy) %in% drops)]
+
+    # Compute ratio dy/dx
+    dydx <- dy / abs_dx
+
+    # There are 10 or  8 output variables 
+    # return partial derivatives as a 8x1 array
+    return (dydx)
+}

--- a/R/errors.R
+++ b/R/errors.R
@@ -1,0 +1,767 @@
+# errors()
+# This subroutine does error propagation on the computation of carbonate system variables 
+# from errors (or uncertainties) on six input 
+#  - pair of carbonate system variables 
+#  - nutrients (silicate and phosphate concentrations)
+#  - temperature and salinity
+# plus errors on dissociation constants pK0, pK1, pK2, pKb, pKw, pKspa and pKspc
+#
+# It propagates error from input to output variables using one of two methods: 
+#    * Gaussian (the method of moments without covariance term)
+#      It is a very general technique for estimating the second moment of a variable z
+#      (variance or standard deviation) based on a first-order approximation to z.
+#      This is the default method.
+#
+#    * Monte Carlo method
+#      It relies on repeated random sampling on input errors to obtain numerical results
+#      from which standard error is estimated
+#
+# Input parameters :
+#   - evar1, evar2   :  standard error (uncertainty) in var1 and var2 of input pair of carbonate system variables
+#   - eS, eT         :  standard error (uncertainty) in Salinity and Temperature
+#   - ePt, eSit      :  standard error (uncertainty) in Phosphate and Silicate total concentrations
+#   - epK            :  standard error (uncertainty) in all 7 dissociation constants (a vector)
+#   - method         :  case insensitive character string : "ga" or "mc"
+#                       default is "ga" (gaussian)
+#   - runs           :  number of random samples (for Monte Carlo method only); default is 10000
+#   - others         :  same as input of subroutine carb(): scalar or vectors
+#
+# All parameters may be scalars or vectors except epK, method, runs and gas.
+#   * method, runs and gas must be scalar
+#   * epK must be vector of seven values : errors of pK0, pK1, pK2, pKb, pKw, pKspa and pKspc
+#     these errors are assumed to be equal for all input data.
+#
+# In constrast, evar1, evar2, eS, eT, ePt and eSit, 
+#   - if vectors, are errors associated with each data point
+#   - if scalars, are one error value associated to all data points
+#
+# Returns a 2-dimensional data-frame, with the folowing columns :
+#   - H      total error to [H+] concentration  (mol/kg)
+#   - pH     total error to pH
+#   - CO2    total error to CO2 concentration (mol/kg)
+#   - pCO2   total error to "standard" pCO2, CO2 partial pressure computed at in situ temperature and atmospheric pressure (µatm)
+#   - fCO2   total error to "standard" fCO2, CO2 fugacity computed at in situ temperature and atmospheric pressure (µatm)
+#   - HCO3   total error to HCO3 concentration (mol/kg)
+#   - CO3    total error to CO3 concentration (mol/kg)
+#   - DIC    total error to DIC concentration (mol/kg)
+#   - ALK    total error to ALK, total alkalinity (mol/kg)
+#   - OmegaAragonite  total error of Omega aragonite (aragonite saturation state)
+#   - OmegaCalcite    total error of Omega calcite   (calcite saturation state)
+#
+# Details :
+#   Computation time depends on the chosen method, with the Monte Carlo approach being more computationally intensive
+#
+#   The Monte Carlo method computation time is proportional to the number of runs.
+#   But more runs means more accurate results :
+#      runs = 10000 appears to be the minimum needed to obtain results with an accuracy of less than 1%
+#      Accuracy is inversely proportional to the number of runs.
+#
+#   Computation time also depends on the type of input pair of variables.
+#     For example, the input pair DIC and Alk (flag=15) requires much more computation time 
+#     than does the input pair pH and Alkalinity (flag=8).
+#
+errors <- 
+function(flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0, evar1=0, evar2=0, eS=0.01, eT=0.01, ePt=0, eSit=0,
+         epK=NULL, method = "ga", runs=10000, k1k2='l', kf='x', ks="d", pHscale="T", b="u74", gas="potential")
+{
+    # Input checking
+    # --------------
+    
+    method <-toupper(method)
+    if (! method %in% c("ga", "mc"))
+        stop ("Invalid input parameter: ", method)
+
+
+    # Input conditionning
+    # -------------------
+    
+    n <- max(length(flag), length(var1), length(var2), length(S), length(T), length(P), length(Pt), length(Sit), 
+             length(evar1), length(evar2), length(eS), length(eT), length(ePt), length(eSit),
+             length(k1k2), length(kf), length(pHscale), length(ks), length(b))
+    if(length(flag)!=n){flag <- rep(flag[1],n)}
+    if(length(var1)!=n){var1 <- rep(var1[1],n)}
+    if(length(var2)!=n){var2 <- rep(var2[1],n)}
+    if(length(S)!=n){S <- rep(S[1],n)}
+    if(length(T)!=n){T <- rep(T[1],n)}
+    if(length(Patm)!=n){Patm <- rep(Patm[1],n)}
+    if(length(P)!=n){P <- rep(P[1],n)}
+    if(length(Pt)!=n){Pt <- rep(Pt[1],n)}
+    if(length(evar1)!=n){evar1 <- rep(evar1[1],n)}
+    if(length(evar2)!=n){evar2 <- rep(evar2[1],n)}
+    if(length(eS)!=n){eS <- rep(eS[1],n)}
+    if(length(eT)!=n){eT <- rep(eT[1],n)}
+    if(length(ePt)!=n){ePt <- rep(ePt[1],n)}
+    if(length(eSit)!=n){eSit <- rep(eSit[1],n)}
+    if(length(k1k2)!=n){k1k2 <- rep(k1k2[1],n)}
+    if(length(kf)!=n){kf <- rep(kf[1],n)}
+    if(length(ks)!=n){ks <- rep(ks[1],n)}
+    if(length(pHscale)!=n){pHscale <- rep(pHscale[1],n)}
+    if(length(b)!=n){b <- rep(b[1],n)}
+
+    # Check sign of all input errors
+    neg_evar1 <- evar1 < 0
+    evar1[neg_evar1] <- -evar1[neg_evar1]
+    neg_evar2 <- evar2 < 0
+    evar2[neg_evar2] <- -evar2[neg_evar2]
+    neg_eS <- eS < 0
+    eS[neg_eS] <- -eS[neg_eS]
+    neg_eT <- eT < 0
+    eT[neg_eT] <- -eT[neg_eT]
+    neg_ePt <- ePt < 0
+    ePt[neg_ePt] <- -ePt[neg_ePt]
+    neg_eSit <- eSit < 0
+    eSit[neg_eSit] <- -eSit[neg_eSit]
+    
+    # Default value for epK
+    if (missing(epK))
+    {
+        epK <- c(0.002, 0.01, 0.02, 0.01, 0.01, 0.01, 0.01)
+    }
+    else
+    {
+        # Check validity of epK
+        if (length(epK) == 1 && epK == 0)
+        {
+            # this means that the caller does not want to account for errors on dissoc. constants
+            epK <- rep(0, 7)
+        }
+        else if (length(epK) != 7)
+            stop ("invalid parameter epK: ", epK)
+        else
+        {
+            # Check sign of given epK
+            neg_ePk <- ePk < 0
+            epK[neg_ePk] <- -epK[neg_ePk] 
+        }
+    }
+    
+    if (method == "ga")
+    {
+        errs <- errors_ga (flag, var1, var2, S, T, Patm, P, Pt, Sit, evar1, evar2, eS, eT, ePt, eSit,
+                epK, k1k2, kf, ks, pHscale, b, gas)
+    }
+    else if (method == "mc")
+    {
+        errs <- errors_mc (flag, var1, var2, S, T, Patm, P, Pt, Sit, evar1, evar2, eS, eT, ePt, eSit,
+                epK, k1k2, kf, ks, pHscale, b, gas, runs)
+    }
+
+    return (errs)
+}
+
+#===========================================================================================
+#                                                                                          #
+#    1st method : Gaussian (method of moments with no covariance terms)                    #
+#                                                                                          #
+#===========================================================================================
+
+# errors_ga()
+#
+# This routine esiimates uncertainties in computed carbonate system variables 
+# by propagating errors (uncertainties) in the six input variables, including 
+#  - the pair of carbonate system variables, 
+#  - the 2 nutrients (total dissolved inorganic silicon and phosphorus concentrations), and
+#  - temperature and salinity, as well as
+# the errors in dissociation constants pK0, pK1, pK2, pKb, pKw, pKspa and pKspc.
+#
+# It computes numerical derivatives then applies them to propagate errors using the Gaussian method
+# The Gaussian method is the standard technique for estimating the second moment of a computed variable z
+# (its variance or standard deviation) based on a first-order approximation to z.
+# The Gaussian method is the same as the method of moments but without covariance terms.
+#
+# Input parameters :
+#   - evar1, evar2   :  standard error (uncertainty) in var1 and in var2 of input pair of carbonate system variables
+#   - eS, eT         :  standard error (uncertainty) in salinity and in temperature
+#   - ePt, eSit      :  standard error (uncertainty) in total dissolved inorganic phosphorus and in total dissolved inorganic silicon concentrations
+#   - epK            :  standard error (uncertainty) in the 7 dissociation constants mentioned above (a vector)
+#   - others         :  same as input of subroutine  carb() : scalar or vectors
+#
+# All parameters may be scalars or vectors except epK and gas.
+#   * gas must be a scalar
+#   * epK must be vector of 7 values : errors of pK0, pK1, pK2, pKb, pKw, pKspa and pKspc
+#     these errors are assumed to be the same for all input data.
+#
+# In constrast, evar1, evar2, eS, eT, ePt and eSit, 
+#   - if vectors, are errors associated with each data point
+#   - if scalars, are one error value associated to all data points
+#
+# Returns a 2-dimensional data-frame, with the folowing columns :
+# - H      total error to [H+] concentration  (mol/kg)
+# - pH     total error to pH
+# - CO2    total error to CO2 concentration (mol/kg)
+# - fCO2   total error to "standard" pCO2, CO2 partial pressure computed at in situ temperature and atmospheric pressure (µatm)
+# - pCO2   total error to "standard" fCO2, CO2 fugacity computed at in situ temperature and atmospheric pressure (µatm)
+# - HCO3   total error to HCO3 concentration (mol/kg)
+# - CO3    total error to CO3 concentration (mol/kg)
+# - DIC    total error to DIC concentration (mol/kg)
+# - ALK    total error to ALK, total alkalinity (mol/kg)
+# - OmegaAragonite  total error of Omega aragonite (aragonite saturation state)
+# - OmegaCalcite    total error of Omega calcite   (calcite saturation state)
+
+errors_ga <- 
+function(flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0, evar1=0, evar2=0, eS=0.01, eT=0.01, ePt=0, eSit=0,
+         epK=NULL, k1k2='l', kf='x', ks="d", pHscale="T", b="u74", gas="potential")
+{
+    # names of dissociation constants
+    Knames <- c ('K0','K1','K2','Kb','Kw','Kspa', 'Kspc')
+
+    # Constant table :  names of input pair variables sorted by flag number
+    varnames  = rbind (
+        c("H", "CO2"),            # flag = 1    
+        c("CO2", "HCO3"),         # flag = 2    
+        c("CO2", "CO3"),          # flag = 3    
+        c("CO2", "ALK"),          # flag = 4    
+        c("CO2", "DIC"),          # flag = 5    
+        c("H", "HCO3"),           # flag = 6    
+        c("H", "CO3"),            # flag = 7    
+        c("H", "ALK"),            # flag = 8    
+        c("H", "DIC"),            # flag = 9    
+        c("HCO3", "CO3"),         # flag = 10   
+        c("HCO3", "ALK"),         # flag = 11   
+        c("HCO3", "DIC"),         # flag = 12   
+        c("CO3", "ALK"),          # flag = 13   
+        c("CO3", "DIC"),          # flag = 14   
+        c("ALK", "DIC"),          # flag = 15 
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("pCO2", "H"),           # flag = 21   
+        c("pCO2", "HCO3"),        # flag = 22   
+        c("pCO2", "CO3"),         # flag = 23   
+        c("pCO2", "ALK"),         # flag = 24   
+        c("pCO2", "DIC")          # flag = 25   
+    )
+    var1name <- varnames[flag,1]
+    var2name <- varnames[flag,2]
+
+    # Convert error on pH to error on [H+] concentration
+    isH <- (var1name == 'H')
+    pH <- var1[isH]
+    epH <- evar1[isH]       # Error on pH
+    H  <- 10**(-pH)         # H+ concentration
+
+    # dpH = d(-log10[H])
+    #     = d(- ln[H] / ln[10] )
+    #     = -(1/ln[10]) * d (ln[H])
+    #     = -(1/ln[10]) * (dH / H)
+    # Thus dH = - ln[1O] * [H] dpH
+    eH <- - log(10) * H * epH
+    evar1[isH] <- eH
+
+    # Same conversion for second variable
+    isH <- (var2name == 'H')
+    pH <- var2[isH]
+    epH <- evar2[isH]       # Error on pH
+    H  <- 10**(-pH)         # H+ concentration
+        
+    eH <- - log(10) * H * epH
+    evar2[isH] <- eH
+
+    # initialise total square error
+    n <- length(flag)
+    sq_err <- numeric(n)
+        
+    # Contribution of var1 to squared standard error
+    if (any (evar1 != 0.0))
+    {
+        # Compute sensitivities (partial derivatives)
+        deriv <- derivnum ('1', flag, var1, var2, S=S, T=T, Patm=Patm, P=P, Pt=Pt, Sit=Sit, k1k2=k1k2, kf=kf, ks=ks, 
+            pHscale=pHscale, b=b, gas=gas)
+        err <- deriv * evar1
+        sq_err <- sq_err + err * err
+    }
+
+    # Contribution of var2 to squared standard error
+    if (any (evar2 != 0.0))
+    {
+        # Compute sensitivities (partial derivatives)
+        deriv <- derivnum ('2', flag, var1, var2, S=S, T=T, Patm=Patm, P=P, Pt=Pt, Sit=Sit, k1k2=k1k2, kf=kf, ks=ks, 
+            pHscale=pHscale, b=b, gas=gas)
+        err <- deriv * evar2
+        sq_err <- sq_err + err * err
+    }
+
+    # Contribution of Silion (total dissolved inorganic concentration) to squared standard error
+    #
+    # Remark : does not compute error where Sit = 0 
+    #          because computation of sensitivity to Sit fails in that case
+    #
+    Sit_valid <- Sit != 0
+    if (any (Sit_valid))
+    {
+        if (any (eSit[Sit_valid] != 0.0))
+        {
+            # Compute sensitivities (partial derivatives)
+            deriv <- derivnum ('sil', flag[Sit_valid], var1[Sit_valid], var2[Sit_valid], S=S[Sit_valid], T=T[Sit_valid],
+                               Patm=Patm[Sit_valid], P=P[Sit_valid], Pt=Pt[Sit_valid], Sit=Sit[Sit_valid], 
+                               k1k2=k1k2[Sit_valid], kf=kf[Sit_valid], ks=ks[Sit_valid], 
+                               pHscale=pHscale[Sit_valid], b=b[Sit_valid], gas=gas)
+            err <- deriv * eSit[Sit_valid]
+            sq_err[Sit_valid] <- sq_err[Sit_valid] + err * err
+        }
+    }
+
+    # Contribution of Phosphorus (total dissoloved inorganic concentration) to squared standard error
+    #
+    # Remark : does not compute error where Pt = 0 
+    #          because computation of sensitivity to Pt fails in that case
+    #
+    Pt_valid <- Pt != 0
+    if (any (Pt_valid))
+    {
+        if (any (ePt[Pt_valid] != 0.0))
+        {
+            # Compute sensitivities (partial derivatives)
+            deriv <- derivnum ('phos', flag[Pt_valid], var1[Pt_valid], var2[Pt_valid], S=S[Pt_valid], T=T[Pt_valid],
+                               Patm=Patm[Pt_valid], P=P[Pt_valid], Pt=Pt[Pt_valid], Sit=Sit[Pt_valid], 
+                               k1k2=k1k2[Pt_valid], kf=kf[Pt_valid], ks=ks[Pt_valid], 
+                               pHscale=pHscale[Pt_valid], b=b[Pt_valid], gas=gas)
+            err <- deriv * ePt[Pt_valid]
+            sq_err[Pt_valid] <- sq_err[Pt_valid] + err * err
+        }
+    }
+
+    # Contribution of T (temperature) to squared standard error
+    if (any (eT != 0.0))
+    {
+        # Compute sensitivities (partial derivatives)
+        deriv <- derivnum ('T', flag, var1, var2, S=S, T=T, Patm=Patm, P=P, Pt=Pt, Sit=Sit, k1k2=k1k2, kf=kf, ks=ks, 
+            pHscale=pHscale, b=b, gas=gas)
+        err <- deriv * eT
+        sq_err <- sq_err + err * err
+    }
+
+    # Contribution of S (salinity) to squared standard error
+    if (any (eS != 0.0))
+    {
+        # Compute sensitivities (partial derivatives)
+        deriv <- derivnum ('S', flag, var1, var2, S=S, T=T, Patm=Patm, P=P, Pt=Pt, Sit=Sit, k1k2=k1k2, kf=kf, ks=ks, 
+            pHscale=pHscale, b=b, gas=gas)
+        err <- deriv * eS
+        sq_err <- sq_err + err * err
+    }
+
+    # Preliminary calculations for dissociation constants
+    if (any (epK != 0))
+    {
+        # Ks (free pH scale) at zero pressure and given pressure
+        Ks_P0 <- Ks(S=S, T=T, P=0, ks=ks)
+        Ks    <- Ks(S=S, T=T, P=P, ks=ks)
+
+        # Kf on free pH scale
+        Kff_P0 <- Kf(S=S, T=T, P=0, pHscale="F", kf=kf, Ks_P0, Ks)
+        Kff <- Kf(S=S, T=T, P=P, pHscale="F", kf=kf, Ks_P0, Ks)
+        # Kf on given pH scale
+        Kf <- Kf(S=S, T=T, P=P, pHscale=pHscale, kf=kf, Ks_P0, Ks)
+
+        # Conversion factor from total to SWS pH scale at zero pressure
+        ktotal2SWS_P0 <- kconv(S=S,T=T,P=P,kf=kf,Ks=Ks_P0,Kff=Kff_P0)$ktotal2SWS
+
+        # Conversion factor from SWS to chosen pH scale
+        conv <- kconv(S=S,T=T,P=P,kf=kf,Ks=Ks,Kff=Kff)
+        kSWS2chosen <- rep(1.,n)
+        kSWS2chosen [pHscale == "T"] <- conv$kSWS2total [pHscale == "T"]
+        kSWS2chosen [pHscale == "F"] <- conv$kSWS2free [pHscale == "F"]  
+    }
+        
+    # Contribution of all pKi to squared standard error
+    for (i in 1:length(epK))
+    {
+        # if error on Ki is given
+        if (epK[i] != 0.0)
+        {
+            # Compute Ki
+            Ki <- switch (i,
+                          K0(S=S, T=T, Patm=Patm, P=0),
+                          K1(S=S, T=T, P=P, pHscale=pHscale, k1k2=k1k2, kSWS2chosen, ktotal2SWS_P0),
+                          K2(S=S, T=T, P=P, pHscale=pHscale, k1k2=k1k2, kSWS2chosen, ktotal2SWS_P0),
+                          Kb(S=S, T=T, P=P, pHscale=pHscale, kSWS2chosen, ktotal2SWS_P0),
+                          Kw(S=S, T=T, P=P, pHscale=pHscale, kSWS2chosen),
+                          Kspa(S=S, T=T, P=P),
+                          Kspc(S=S, T=T, P=P)
+                          )
+            # compute error on Ki from that on pKi
+            eKi <- - epK[i] * Ki * log(10)
+            # Compute sensitivities (partial derivatives)
+            deriv <- derivnum (Knames[i], flag, var1, var2, S=S, T=T, Patm=Patm, P=P, Pt=Pt, Sit=Sit, k1k2=k1k2, kf=kf, ks=ks, 
+                pHscale=pHscale, b=b, gas=gas)
+            err <- deriv * eKi
+            sq_err <- sq_err + err * err
+        }
+    }
+
+    # Compute resulting total error (or uncertainty)
+    error <- sqrt (sq_err)
+
+    return (error)
+}
+
+
+#===========================================================================================
+#                                                                                          #
+#    2nd method : Monte Carlo                                                              #
+#                                                                                          #
+#===========================================================================================
+
+# Function that computes standard deviation 
+# on first dimension of a given 3D matrix "x"
+Sd_3D_1stD <- function(x)
+{          
+    first_dim <- dim(x)[1]
+    # Compute mean over first dimension
+    x_mean <- colMeans(x)
+    # x_mean is a 2D array
+    # Extend array x_mean to 3D by replication
+    new_dim <- c(dim(x_mean), first_dim)
+    x_mean <- array (x_mean, new_dim)
+    # Transpose extended x_mean so that it conforms to array x
+    x_mean <- aperm (x_mean, c(3,1,2))
+
+    # Compute mean-centered array
+    y <- x - x_mean
+    # Compute variance estimator
+    var <- colMeans(y^2)*(first_dim/(first_dim-1))
+
+    return (sqrt(var))
+}
+
+
+# Function that generates deviate values for dissoc. constants Kx from given error on pKx
+#
+# Special case for K0 :
+#    This function generates a set of small deltas departing from 0 whose distribution is close to normal
+#    These deltas will then be used to generate deviate samples of K0, from standard value of K0
+#
+# Other cases : K1, K2, Kb, Kw, Kspa and Kspc
+#    This function generates a set of deviate values for dissociation constant Kx
+#    Distribution of that set is close to a Normal distribution centered on standard value of Kx
+#
+# Input parameters :
+#   - epK      :  standard error (or uncertainty) on all seven dissociation constants (a vector of length 7)
+#   - S, T, P  :  Salinity, Temperature and Pressure, vectors of same length n
+#   - Patm     :  Surface atmospheric pressure in atm, vector of length n
+#   - pHscale  :  pH scale, character ("T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale)
+#                 vector of length n
+#   - k1k2     :  option for dissociation constants K1 and K2, vector of length n
+#   - kf, ks   :  options for dissociation constants Kf and Ks, vectors of length n
+#   - runs     :  number of runs of Monte Carlo (= number of deviates per sample)
+#
+# Returns a 2-dimensional data-frame, with 7 columns: K0, K1, K2, Kb, Kw, Kspa and Kspc 
+#   each column contains deviate delta values of one dissociation constant
+#   column length is n * runs
+#
+gen_delta_Kx <- function (epK, S, T, P, Patm, pHscale, k1k2, kf, ks, runs)
+{
+    n <- length(S)
+    # names of dissociation constants
+    Knames <- c ('K0','K1','K2','Kb','Kw','Kspa', 'Kspc')
+
+    # Initalise output data frame
+    nrows <- n * runs
+    delta_Kx <- data.frame (matrix( numeric(0), nrow=nrows, ncol=0))
+
+    # Devise a function that generates simulation samples
+    # for one variable with central value "val" and standard error "std_err"
+    gen_sim <- function (val, std_err)
+    {
+        # if no standard error"
+        if (all(std_err == 0))
+            # Replicate variable value
+            sim_array <- rep(val, times=runs)
+        else
+        {
+            # Generate deviates from value using Normal distribution
+            sim_array <- rnorm(runs, val, std_err)
+            # Set to zero all negative values
+            sim_array[sim_array < 0] = 0.0
+        }
+        return(sim_array)
+    }
+
+    # Preliminary calculations for dissociation constants
+
+    # Ks (free pH scale) at zero pressure and given pressure
+    Ks_P0 <- Ks(S=S, T=T, P=0, ks=ks)
+    Ks    <- Ks(S=S, T=T, P=P, ks=ks)
+
+    # Kf on free pH scale
+    Kff_P0 <- Kf(S=S, T=T, P=0, pHscale="F", kf=kf, Ks_P0, Ks)
+    Kff <- Kf(S=S, T=T, P=P, pHscale="F", kf=kf, Ks_P0, Ks)
+    # Kf on given pH scale
+    Kf <- Kf(S=S, T=T, P=P, pHscale=pHscale, kf=kf, Ks_P0, Ks)
+
+    # Conversion factor from total to SWS pH scale at zero pressure
+    ktotal2SWS_P0 <- kconv(S=S,T=T,P=P,kf=kf,Ks=Ks_P0,Kff=Kff_P0)$ktotal2SWS
+
+    # Conversion factor from SWS to chosen pH scale
+    conv <- kconv(S=S,T=T,P=P,kf=kf,Ks=Ks,Kff=Kff)
+    kSWS2chosen <- rep(1.,n)
+    kSWS2chosen [pHscale == "T"] <- conv$kSWS2total [pHscale == "T"]
+    kSWS2chosen [pHscale == "F"] <- conv$kSWS2free [pHscale == "F"]  
+
+    # Convert error on pKi to error on Ki
+    for (i in 1:length(epK))
+    {
+        # Compute Ki
+        Ki <- switch (i,
+                      seacarb::K0(S=S, T=T, Patm=Patm, P=0),
+                      seacarb::K1(S=S, T=T, P=P, pHscale=pHscale, k1k2=k1k2, kSWS2chosen, ktotal2SWS_P0),
+                      seacarb::K2(S=S, T=T, P=P, pHscale=pHscale, k1k2=k1k2, kSWS2chosen, ktotal2SWS_P0),
+                      seacarb::Kb(S=S, T=T, P=P, pHscale=pHscale, kSWS2chosen, ktotal2SWS_P0),
+                      seacarb::Kw(S=S, T=T, P=P, pHscale=pHscale, kSWS2chosen),
+                      seacarb::Kspa(S=S, T=T, P=P),
+                      seacarb::Kspc(S=S, T=T, P=P)
+                      )
+        if (i == 1)
+            center_value = 0.0    # special case for K0
+        else
+            center_value = Ki
+
+        # if error on Ki is given
+        if (epK[i] != 0.0)
+        {
+            # compute error (not signed) on Ki from that on pKi
+            eKi <- epK[i] * Ki * log(10)
+            # Generate deviate values for Ki or deltas for K0
+            spl_Ki <- mapply (gen_sim, center_value, eKi)
+            # Reshape samples from 2D matrix to vector
+            dim(spl_Ki) <- c(n*runs)
+        }
+        else
+        {
+            # Simply replicate value of Ki or  replicate 0.0 for K0
+            spl_Ki <- rep (center_value, each=runs)
+        }
+
+        # Store (deviate) values for Ki in a data frame column
+        Kname <- Knames[i]
+        delta_Kx[[Kname]] <- spl_Ki
+    }
+    return (delta_Kx)
+}
+
+
+# errors()
+# This subroutine does error propagation on the computation of carbonate system variables 
+# from errors (or uncertainties) on six input 
+#  - pair of carbonate system variables 
+#  - nutrients (silicate and phosphate concentrations)
+#  - temperature and salinity
+# plus errors on dissociation constants pK0, pK1, pK2, pKb, pKw, pKspa and pKspc
+#
+# It computes standard error on carbonate system output variables using Monte Carlo method.
+#
+# Input parameters :
+#   - evar1, evar2   :  standard error (or uncertainty) on var1 and var2 of input pair of carbonate system variables
+#   - eS, eT         :  standard error (or uncertainty) on Salinity and Temperature
+#   - ePt, eSit      :  standard error (or uncertainty) on Phosphate and Silicate total concentrations
+#   - epK            :  standard error (or uncertainty) on all seven dissociation constants (a vector)
+#   - runs           :  number of runs of Monte Carlo (= number of simulated samples)
+#                       default is 10000
+#   - others         :  same as input of subroutine  carb() : scalar or vectors
+#
+# All parameters may be scalars or vectors except epK, method, runs and gas.
+#   * runs and gas must be scalars
+#   * epK must be vector of seven values : errors of pK0, pK1, pK2, pKb, pKw, pKspa and pKspc
+#     these errors are assumed to be equal for all input data.
+#
+# In constrast, for evar1, evar2, eS, eT, ePt and eSit,\cr
+#   - if they are vectors, they represent errors associated with each data point\cr
+#   - if they are scalars, they represent one error value each associated to all data points
+#
+# Returns a 2-dimensional data-frame, with the folowing columns :
+# - H      total error to [H+] concentration  (mol/kg)
+# - pH     total error to pH
+# - CO2    total error to CO2 concentration (mol/kg)
+# - fCO2   total error to "standard" pCO2, CO2 partial pressure computed at in situ temperature and atmospheric pressure (µatm)
+# - pCO2   total error to "standard" fCO2, CO2 fugacity computed at in situ temperature and atmospheric pressure (µatm)
+# - HCO3   total error to HCO3 concentration (mol/kg)
+# - CO3    total error to CO3 concentration (mol/kg)
+# - DIC    total error to DIC concentration (mol/kg)
+# - ALK    total error to ALK, total alkalinity (mol/kg)
+# - OmegaAragonite  total error of Omega aragonite (aragonite saturation state)
+# - OmegaCalcite    total error of Omega calcite   (calcite saturation state)
+#
+# Remarks :
+#   Accuracy is strongly depending on number of runs. Default run number is 10,000, 
+#   You may want to choose a number of 100,000 runs or more, but beware that such calculations may take several seconds per data point.
+#
+errors_mc <- 
+function(flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0, evar1=0, evar2=0, eS=0.01, eT=0.01, ePt=0, eSit=0,
+         epK=NULL, k1k2='l', kf='x', ks="d", pHscale="T", b="u74", gas="potential", runs=10000)
+{
+    # Constant table :  names of input pair variables sorted by flag number
+    varnames  = rbind (
+        c("H", "CO2"),            # flag = 1    
+        c("CO2", "HCO3"),         # flag = 2    
+        c("CO2", "CO3"),          # flag = 3    
+        c("CO2", "ALK"),          # flag = 4    
+        c("CO2", "DIC"),          # flag = 5    
+        c("H", "HCO3"),           # flag = 6    
+        c("H", "CO3"),            # flag = 7    
+        c("H", "ALK"),            # flag = 8    
+        c("H", "DIC"),            # flag = 9    
+        c("HCO3", "CO3"),         # flag = 10   
+        c("HCO3", "ALK"),         # flag = 11   
+        c("HCO3", "DIC"),         # flag = 12   
+        c("CO3", "ALK"),          # flag = 13   
+        c("CO3", "DIC"),          # flag = 14   
+        c("ALK", "DIC"),          # flag = 15 
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("", ""),
+        c("pCO2", "H"),           # flag = 21   
+        c("pCO2", "HCO3"),        # flag = 22   
+        c("pCO2", "CO3"),         # flag = 23   
+        c("pCO2", "ALK"),         # flag = 24   
+        c("pCO2", "DIC")          # flag = 25   
+    )
+
+    # Devise a function that generates simulation samples 
+    # for one variable with central value "val" and standard error "std_err"
+    gen_sim <- function (val, std_err)
+    {
+        # if no standard error"
+        if (all(std_err == 0))
+            # Replicate variable value
+            sim_array <- rep(val, times=runs)
+        else
+        {
+            # Generate deviates from value using Normal distribution
+            sim_array <- rnorm(runs, val, std_err)
+            # Set to zero all negative values
+            sim_array[sim_array < 0] = 0.0
+        }
+        return(sim_array)
+    }
+
+    # Generate deviate sample values for var1
+    spl_var1 <- mapply (gen_sim, var1, evar1)
+    # Same for var2, Salinity, Temperature, Phosphate and Silicate
+    spl_var2 <- mapply (gen_sim, var2, evar2)
+    spl_S    <- mapply (gen_sim, S, eS)
+    spl_T    <- mapply (gen_sim, T, eT)
+    spl_Pt   <- mapply (gen_sim, Pt, ePt)
+    spl_Sit  <- mapply (gen_sim, Sit, eSit)
+
+    # Reshape samples from 2D matrix to vector
+    n <- length(var1)
+    dim(spl_var1) <- c(n*runs)
+    dim(spl_var2) <- c(n*runs)
+    dim(spl_S)    <- c(n*runs)
+    dim(spl_T)    <- c(n*runs)
+    dim(spl_Pt)   <- c(n*runs)
+    dim(spl_Sit)  <- c(n*runs)
+        
+    # Generate deviate delta values for K0
+    # Generate deviate values for other dissoc. constants Kx
+    spl_Kx <- gen_delta_Kx (epK, S, T, P, Patm, pHscale, k1k2, kf, ks, runs)
+
+    # All other parameters and variables
+    spl_flag <- rep (flag, each=runs)
+    spl_Patm <- rep (Patm, each=runs)
+    spl_P    <- rep (P, each=runs)
+    spl_k1k2 <- rep (k1k2, each=runs)
+    spl_kf   <- rep (kf, each=runs)
+    spl_ks   <- rep (ks, each=runs)
+    spl_pHscale <- rep (pHscale, each=runs)
+    spl_b    <- rep (b, each=runs)
+
+    # Define local functions K0, K1, K2, ...
+    # --------------------------------------
+
+    # Special case for K0
+    #
+    # It computes original K0 values then add precalculated deltas to generate 
+    # and return deviate values
+    K0 <- function(S=35,T=25,P=0,Patm=1)
+    {
+        # Call original K0 function
+        out <- seacarb::K0(S, T, P, Patm=Patm)
+        # perturb value of K0 by adding deltas
+        out = out + spl_Kx$K0
+        return (out)
+    }
+    # General case : all other
+    # The function return precalculated deviate values
+    K1 <- function(S=35,T=25,P=0,k1k2='x',pHscale="T",kSWS2scale=0,ktotal2SWS_P0=0)  spl_Kx$K1
+    K2 <- function(S=35,T=25,P=0,k1k2='x',pHscale="T",kSWS2scale=0,ktotal2SWS_P0=0)  spl_Kx$K2
+    Kw <- function(S=35,T=25,P=0,pHscale="T",kSWS2scale=0)  spl_Kx$Kw
+    Kb <- function(S=35,T=25,P=0,pHscale="T",kSWS2scale=0,ktotal2SWS_P0=0)  spl_Kx$Kb
+    Kspa <- function(S=35,T=25,P=0)  spl_Kx$Kspa
+    Kspc <- function(S=35,T=25,P=0)  spl_Kx$Kspc
+
+    # Note : in the general case (K1, K2,...) the function Kx is called once by the function carb()
+    #        We can call the function in anticipation and substitute real values with deviate values
+    #        at run time.
+    #        in the special case of K0, function K0() is called twice, twice by function carb()
+    #        We must generate deviate values at run time, when K0() is called.
+    #        This is the purpose of locally defined K0() function
+    
+    # Save then change execution environment of function carb()
+    saved_env <- environment(carb)
+    # Using environment(K0) will hide original seacarb::K0, seacarb::K1, ... functions
+    environment(carb) <- environment(NULL)
+    # Note :  environment(NULL) is the environment created when this function errors_mc() is executed
+    #         It then contains all locally defined functions, like K0, K1, K2, ...
+    #         Then, when carb() is executed and looks for a name (variable or function) that is not a local variable,
+    #         it will look into evironment(NULL), which has been attached to it, 
+    #         before looking into global or seacarb module environment.
+
+    # Compute output carbonate system variables
+    seacarb = carb(spl_flag, spl_var1, spl_var2, S=spl_S, T=spl_T, Patm=spl_Patm, P=spl_P, Pt=spl_Pt, Sit=spl_Sit, 
+                spl_k1k2, spl_kf, spl_ks, spl_pHscale, spl_b)
+
+    # Restore environment of carb()
+    environment(carb) <- saved_env
+
+    # Add one column for [H+]
+    H <- 10^(-seacarb$pH)
+    seacarb <- cbind(H,seacarb)
+
+    # Drop unnecessary columns
+    drops=c('flag', 'S', 'T', 'P', 'Patm', 'fCO2pot', 'pCO2pot', 'fCO2insitu', 'pCO2insitu')
+    seacarb <- seacarb[,!(names(seacarb) %in% drops)]
+        
+    # if all input pairs are of same type
+    if (all(flag == flag[1]))
+    {
+        # Drop input pair
+        var1name <- varnames[flag[1],1]
+        var2name <- varnames[flag[1],2]
+        drops=c(var1name, var2name)
+        # if to drop H, drop also pH
+        if (var1name == 'H' || var2name == 'H')   drops = c(drops, 'pH')
+        seacarb <- seacarb[,!(names(seacarb) %in% drops)]
+    }
+    
+    # if more than one data point
+    if (n > 1)
+    {
+        # Reshape results to a matrix
+        seacarb_3D <- data.matrix(seacarb)
+        # Reshape to a 3D array
+        nvars <- dim(seacarb)[2]
+        dim(seacarb_3D) <- c(runs, n, nvars)
+
+        # Compute standard deviation on all simulated samples
+        std_dev <- Sd_3D_1stD (seacarb_3D)
+        # Convert to data frame
+        std_dev <- data.frame (std_dev)
+        colnames(std_dev) <- colnames(seacarb)
+    }
+    else
+    {
+        # devise a function that computes standard deviation on columns of a given 2D matrix "x"
+        colSd_2D <- function(x)sqrt(rowMeans((t(x)-colMeans(x))^2)*((dim(x)[1])/(dim(x)[1]-1)))
+
+        # Compute standard deviation on all simulated samples
+        std_dev <- data.frame(t(colSd_2D(seacarb)))
+    }
+        
+    return (std_dev)
+}

--- a/man/buffesm.Rd
+++ b/man/buffesm.Rd
@@ -3,7 +3,7 @@
 \alias{buffesm}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{Buffer capacities of the seawater carbonate system as defined by Egleston et al. (2010)}
-\description{Returns the six buffer factors of the seawater carbonate system as defined by Egleston, Sabine and Morel (2010), denoted here as ESM. Also returns the classic Revelle factor (relative change in pCO2 over that for DIC). In ESM, there are errors in the equations in Table 1 for \eqn{S}, \eqn{\Omega_{DIC}}, and \eqn{\Omega_{Alk}}. These errors have been corrected here.  The results of this routine have been validated: they produce results that are identical to those shown in ESM's Fig. 2. This routine was inspired and adapted from seacarb's ``buffer'' function. Its input arguments are indentical to those in the ``buffer'' and ``carb'' functions of seacarb.}
+\description{Returns the six buffer factors of the seawater carbonate system as defined by Egleston, Sabine and Morel (2010), denoted here as ESM. Also returns the classic Revelle factor (relative change in pCO2 over that for DIC). In ESM, there are errors in the equations in Table 1 for \eqn{S}, \eqn{\Omega_{DIC}}, and \eqn{\Omega_{Alk}}. These errors have been corrected here.  The results of this routine have been validated: when input concentrations of Pt and Sit are set to zero, they produce results that are identical to those shown in ESM's Fig. 2. But when Pt and Sit are nonzero, contributions from phosphoric and silicic acid systems are taken into account, an improvement to the Egleston et al. (2010) approach. This routine was inspired and adapted from seacarb's ``buffer'' function. Its input arguments are indentical to those in the ``buffer'' and ``carb'' functions of seacarb.}
 \usage{
 buffesm(flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0, k1k2="x", 
 	kf="x", ks="d", pHscale="T", b="u74")
@@ -58,8 +58,8 @@ flag = 25     pCO2 and DIC given
 	\item{T}{Temperature in degrees Celsius}
         \item{Patm}{Surface atmospheric pressure in atm, default 1 atm}
   	\item{P}{Hydrostatic pressure in bar (surface = 0)}
-  	\item{Pt}{Concentration of total phosphate in mol/kg; set to 0 if NA}
-  	\item{Sit}{Concentration of total silicate in mol/kg; set to 0 if NA}
+  	\item{Pt}{Concentration of total phosphate in mol/kg; set to 0 if NA; when nonzero, account for phosphoric acid system, unlike in Egleston et al. (2010).}
+  	\item{Sit}{Concentration of total silicate in mol/kg; set to 0 if NA; when nonzero, account for phosphoric acid system, unlike in Egleston et al. (2010).}
         \item{k1k2}{"l" for using K1 and K2 from Lueker et al. (2000), "m06" from Millero et al. (2006), "m10" from Millero (2010), "w14" from Waters et al. (2014), and "r" from Roy et al. (1993). "x" is the default flag; the default value is then "l", except if T is outside the range 2 to 35oC and/or S is outside the range 19 to 43. In these cases, the default value is "m10".}
   	\item{kf}{"pf" for using Kf from Perez and Fraga (1987) and "dg" for using Kf from Dickson and Riley (1979 in Dickson and Goyet, 1994). "x" is the default flag; the default value is then "pf", except if T is outside the range 9 to 33oC and/or S is outside the range 10 to 40. In these cases, the default is "dg".}
 	\item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"} 

--- a/man/derivnum.Rd
+++ b/man/derivnum.Rd
@@ -1,0 +1,204 @@
+\encoding{latin1}
+\name{derivnum}
+\alias{derivnum}
+\title{Numerical derivatives of seawater carbonate system variables}
+\description{Returns numerical derivatives  of the seawater carbonate system putput variables with respect to input variables.}
+\usage{derivnum(varid, flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0,
+       k1k2="x", kf="x", ks="d", pHscale="T", b="u74", gas="potential")}
+%- maybe also 'usage' for other objects documented here.
+\arguments{
+\item{varid}{Variable length, case insensitive, character identificator of variable with respect to which derivatives are requested.
+Possible values are:
+
+'1' or 'var1'  :  Variable 1 of the input pair (This is TAlk if flag is 15)
+
+'2' or 'var2'  :  Variable 2 of the input pair (This is DIC  if flag is 15)
+
+'sil', 'silt', 'tsil' or 'silicate'      : Total silicate concentration
+
+'phos', 'phost', 'tphos' or 'phosphate'  : Total phosphate concentration
+
+'t', 'temp' or 'temperature' : temperature
+
+'s', 'sal' or 'salinity'     : salinity
+}
+\item{flag}{select the couple of variables available. The flags which can be used are:
+
+flag = 1      pH and CO2 given
+
+flag = 2      CO2 and HCO3 given
+
+flag = 3      CO2 and CO3 given
+
+flag = 4      CO2 and ALK given
+
+flag = 5      CO2 and DIC given
+
+flag = 6      pH and HCO3 given
+
+flag = 7      pH and CO3 given
+
+flag = 8      pH and ALK given
+
+flag = 9      pH and DIC given
+
+flag = 10     HCO3 and CO3 given
+
+flag = 11     HCO3 and ALK given
+
+flag = 12     HCO3 and DIC given
+
+flag = 13     CO3 and ALK given
+
+flag = 14     CO3 and DIC given
+
+flag = 15     ALK and DIC given
+
+flag = 21     pCO2 and pH given
+
+flag = 22     pCO2 and HCO3 given
+
+flag = 23     pCO2 and CO3 given
+
+flag = 24     pCO2 and ALK given
+
+flag = 25     pCO2 and DIC given
+}
+\item{var1}{Value of the first  variable in mol/kg, except for pH and for pCO2 in \eqn{\mu}atm}
+\item{var2}{Value of the second  variable in mol/kg, except for pH}
+\item{S}{Salinity}
+\item{T}{Temperature in degrees Celsius}
+ \item{Patm}{Surface atmospheric pressure in atm, default is 1 atm}
+ \item{P}{Hydrostatic pressure in bar (surface = 0)}
+ \item{Pt}{Concentration of total phosphate in mol/kg; set to 0 if NA}
+ \item{Sit}{Concentration of total silicate in mol/kg; set to 0 if NA}
+ \item{k1k2}{"l" for using K1 and K2 from Lueker et al. (2000), "m06" from Millero et al. (2006), "m10" from Millero (2010), "w14" from Waters et al. (2014), and "r" from Roy et al. (1993). "x" is the default flag; the default value is then "l", except if T is outside the range 2 to 35oC and/or S is outside the range 19 to 43. In these cases, the default value is "m10".}
+\item{kf}{"pf" for using Kf from Perez and Fraga (1987) and "dg" for using Kf from Dickson and Riley (1979 in Dickson and Goyet, 1994). "x" is the default flag; the default value is then "pf", except if T is outside the range 9 to 33oC and/or S is outside the range 10 to 40. In these cases, the default is "dg".}
+\item{ks}{"d" for using Ks from Dickson (1990) and "k" for using Ks from Khoo et al. (1977), default is "d"}
+\item{pHscale}{"T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
+\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74" }
+ \item{gas}{used to indicate the convention for INPUT pCO2, i.e., when it is an input variable (flags 21 to 25): "insitu" indicates it is referenced to in situ pressure and in situ temperature; "potential" indicates it is referenced to 1 atm pressure and potential temperature; and "standard" indicates it is referenced to 1 atm pressure and in situ temperature. All three options should give identical results at surface pressure. This option is not used when pCO2 is not an input variable (flags 1 to 15). The default is "potential".}
+}
+
+\details{
+This subroutine has same input parameters as subroutine carb(). For details on these parameters,
+refer to documentation of 'carb'.
+
+This subroutine computes partial derivatives of each output variable with respect to
+each of the input variable (including each of the two chosen carbonate system
+variables, each of the nutrients (total silicon and total phosphorus), temperature,
+and salinity.
+
+It computes these derivatives (dy/dx) using the method of central differences, i.e.,
+\itemize{
+  \item for dx, it adds a positive and negative perturbation, same and equal in magnitude, to each input variable, one at a time, and
+  \item for dy, it then computes the corresponding induced change in output variables
+}
+
+All arguments but the first (varid), can be given as scalers or vectors. If the
+lengths of the vectors differs, only the longest vector is retained and the other
+arguments are set equal to the first value of the other vectors are used. Hence users
+should use either vectors with the same dimension or one vector for one argument and
+scalars for others; otherwise, results may not be as intended.
+}
+
+\value{The function returns a data frame containing the following columns:
+ \item{H}{derivative of [H+] concentration  (mol/kg/...)}
+ \item{pH}{derivative of pH}
+ \item{CO2}{derivative of CO2 concentration (mol/kg/...)}
+ \item{pCO2}{"standard" pCO2, CO2 partial pressure computed at in situ temperature and atmospheric pressure (\eqn{\mu}atm/...)}
+ \item{fCO2}{"standard" fCO2, CO2 fugacity computed at in situ temperature and atmospheric pressure (\eqn{\mu}atm/...)}
+ \item{HCO3}{derivative of HCO3 concentration (mol/kg/...)}
+ \item{CO3}{derivative of CO3 concentration (mol/kg/...)}
+ \item{DIC}{derivative of DIC concentration (mol/kg/...)}
+ \item{ALK}{derivative of ALK, total alkalinity (mol/kg/...)}
+ \item{OmegaAragonite}{derivative of Omega aragonite, aragonite saturation state}
+ \item{OmegaCalcite}{derivative of Omega calcite, calcite saturation state}
+
+If all input data have the same 'flag' value, returned data frame does not show
+derivatives of input pair of carbonate system variables. For example, if all input
+flags are 15, the input pair is DIC and ALK; hence, derivatives of DIC and ALK are
+not returned.
+
+Units of derivative dy/dx is unit(y)/unit(x) where unit(x) are as follows:
+ \item{degree C}{when x is Temperature}
+ \item{psu}{when x is Salinity}
+ \item{\eqn{\mu}atm}{when x is pCO2}
+ \item{mol/kg}{for all other cases}
+}
+
+\references{
+Dickson A. G. and Riley J. P., 1979 The estimation of acid dissociation constants in seawater media from potentiometric titrations with strong base. I. The ionic product of water. \emph{Marine Chemistry} \bold{7}, 89-99.
+
+Dickson A. G., 1990 Standard potential of the reaction: AgCI(s) + 1/2H2(g) = Ag(s) + HCI(aq), and the standard acidity constant of the ion HSO4 in synthetic sea water from 273.15 to 318.15 K. \emph{Journal of Chemical Thermodynamics} \bold{22}, 113-127.
+
+Dickson A. G., Sabine C. L. and Christian J. R., 2007 Guide to best practices for ocean CO2 measurements. \emph{PICES Special Publication} \bold{3}, 1-191.
+
+Khoo H. K., Ramette R. W., Culberson C. H. and Bates R. G., 1977 Determination of Hydrogen Ion Concentration in Seawater from 5 to 40oC: Standard Potentials at Salinities from 20 to 45. \emph{Analytical Chemistry} \bold{22}, vol49 29-34.
+
+Lee K., Tae-Wook K., Byrne R.H., Millero F.J., Feely R.A. and Liu Y-M, 2010 The universal ratio of the boron to chlorinity for the North Pacific and North Atlantoc oceans. \emph{Geochimica et Cosmochimica Acta} \bold{74} 1801-1811.
+
+Lueker T. J., Dickson A. G. and Keeling C. D., 2000 Ocean pCO2 calculated from dissolved inorganic carbon, alkalinity, and equations for K1 and K2: validation based on laboratory measurements of CO2 in gas and seawater at equilibrium. \emph{Marine Chemistry} \bold{70} 105-119.
+
+Millero F. J., 1995. Thermodynamics of the carbon dioxide system in the oceans. \emph{Geochimica Cosmochimica Acta} \bold{59}: 661-677.
+
+Millero F. J., 2010. Carbonate constant for estuarine waters. \emph{Marine and Freshwater Research} \bold{61}: 139-142.
+
+Millero F. J., Graham T. B., Huang F., Bustos-Serrano H. and Pierrot D., 2006. Dissociation constants of carbonic acid in seawater as a function of salinity and temperature.  \emph{Marine Chemistry} \bold{100}, 80-84.
+
+Orr J. C., Epitalon J.-M. and Gattuso J.-P., 2014. Comparison of seven packages that compute ocean carbonate chemistry. \emph{Biogeosciences Discussions} \bold{11}, 5327-5397.
+
+Perez F. F. and Fraga F., 1987 Association constant of fluoride and hydrogen ions in seawater. \emph{Marine Chemistry} \bold{21}, 161-168.
+
+Roy R. N., Roy L. N., Vogel K. M., Porter-Moore C., Pearson T., Good C. E., Millero F. J. and Campbell D. M., 1993. The dissociation constants of carbonic acid in seawater at salinities 5 to 45 and temperatures 0 to 45oC. \emph{Marine Chemistry} \bold{44}, 249-267.
+
+Uppstrom L.R., 1974 The boron/chlorinity ratio of the deep-sea water from the Pacific Ocean. \emph{Deep-Sea Research I} \bold{21} 161-162.
+
+Waters, J., Millero, F. J., and Woosley, R. J., 2014. Corrigendum to ``The free proton concentration scale for seawater pH'', [MARCHE: 149 (2013) 8-22], Mar. Chem. 165, 66-67.
+
+Weiss, R. F., 1974. Carbon dioxide in water and seawater: the solubility of
+a non-ideal gas, \emph{Mar.  Chem.}, \bold{2}, 203-215.
+
+Weiss, R. F. and Price, B. A., 1980. Nitrous oxide solubility in water and
+seawater, \emph{Mar. Chem.}, \bold{8}, 347-359.
+
+Zeebe R. E. and Wolf-Gladrow D. A., 2001 \emph{CO2 in seawater: equilibrium, kinetics, isotopes}. Amsterdam: Elsevier, 346 pp.
+}
+
+\author{
+Jean-Marie Epitalon, James Orr, and Jean-Pierre Gattuso\email{gattuso@obs-vlfr.fr}
+}
+
+\examples{
+
+## 1) For the input pair ALK and DIC (var1 and var2 when flag=15)
+## compute derivatives of all output varialbes with respect to DIC (i.e., var2)
+derivnum(varid='var2', flag=15, var1=2300e-6, var2=2000e-6, S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0,
+pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
+
+## 2) For the input pair pH and ALK (var1 and var2 when flag=8)
+## compute derivatives of all output variables with respect to [H+] concentration
+derivnum(varid='var1', flag=8, var1=8.2, var2=0.00234, S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0,
+pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
+
+## 3) Using vectors as arguments and compute derivatives of all output variables with respect to temperature
+flag <- c(8, 2, 8)
+var1 <- c(8.2, 7.477544e-06, 8.2)
+var2 <- c(0.002343955, 0.001649802, 2400e-6)
+S <- c(35, 35, 30)
+T <- c(25, 25, 30)
+P <- c(0, 0, 0)
+Pt <- c(0, 0, 0)
+Sit <- c(0, 0, 0)
+kf <- c("pf", "pf", "pf")
+k1k2 <- c("l", "l", "l")
+pHscale <- c("T", "T", "T")
+b <- c("u74", "u74", "u74")
+derivnum(varid='T', flag=flag, var1=var1, var2=var2, S=S, T=T, P=P,
+ Pt=Pt, Sit=Sit, kf=kf, k1k2=k1k2, pHscale=pHscale, b=b)
+
+# For more examples of use of derivnum.R,
+# consult the code of seacarb's errors routine.
+}
+
+\keyword{utilities}

--- a/man/errors.Rd
+++ b/man/errors.Rd
@@ -1,0 +1,239 @@
+\encoding{latin1}
+\name{errors}
+\alias{errors}
+\title{Error propagation for computed marine carbonate system variables}
+\description{Estimates uncertainties in computed carbonate system variables by propagating standard error (uncertainty) in six input variables, including
+  * the input pair of carbonate system variables, 
+  * the 2 input nutrients (silicate and phosphate concentrations),
+  * temperature and salinity, as well as
+the errors in the key dissociation constants pK0, pK1, pK2, pKb, pKw, pKspa and pKspc
+}
+\usage{errors(flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0, evar1=0, evar2=0, eS=0.01, eT=0.01, ePt=0, eSit=0,
+         epK=NULL, method = "ga", runs=10000, k1k2='l', kf='x', ks="d", pHscale="T", b="u74", gas="potential")}
+%- maybe also 'usage' for other objects documented here.
+\arguments{
+\item{flag}{select the pair of carbonate system input variables. The flags to be used are as follows:
+
+flag = 1      pH and CO2 given
+
+flag = 2      CO2 and HCO3 given
+
+flag = 3      CO2 and CO3 given
+
+flag = 4      CO2 and ALK given
+
+flag = 5      CO2 and DIC given
+
+flag = 6      pH and HCO3 given
+
+flag = 7      pH and CO3 given
+
+flag = 8      pH and ALK given
+
+flag = 9      pH and DIC given
+
+flag = 10     HCO3 and CO3 given
+
+flag = 11     HCO3 and ALK given
+
+flag = 12     HCO3 and DIC given
+
+flag = 13     CO3 and ALK given
+
+flag = 14     CO3 and DIC given
+
+flag = 15     ALK and DIC given
+
+flag = 21     pCO2 and pH given
+
+flag = 22     pCO2 and HCO3 given
+
+flag = 23     pCO2 and CO3 given
+
+flag = 24     pCO2 and ALK given
+
+flag = 25     pCO2 and DIC given
+}
+\item{var1}{Value of the first variable (in mol/kg, except for pH and for pCO2 in \eqn{\mu}atm)}
+\item{var2}{Value of the second variable (in mol/kg, except for pH)}
+\item{S}{Salinity (practical salinity scale)}
+\item{T}{Temperature in degrees Celsius}
+\item{Patm}{Surface atmospheric pressure in atm, default is 1 atm}
+\item{P}{Hydrostatic pressure in bar (surface = 0)}
+\item{Pt}{Concentration of total dissolved inorganic phosphorus (mol/kg); set to 0 if NA}
+\item{Sit}{Concentration of total dissolved inorganic silicon (mol/kg); set to 0 if NA}
+\item{evar1}{Standard error (uncertainty) in var1 of input pair of carbonate system variables}
+\item{evar2}{Standard error (uncertainty) in var2 of input pair of carbonate system variables}
+\item{eS}{Standard error (uncertainty) in salinity (psu)}
+\item{eT}{Standard error (uncertainty) in temperature (degree C)}
+\item{ePt}{Standard error (uncertainty) in total dissolved inorganic phosphorus concentration (mol/kg)}
+\item{eSit}{Standard error (uncertainty)in total dissolved inorganic silicon concentration (mol/kg)}
+\item{epK}{Standard error (uncertainty) in 7 key dissociation constants (a vector)}
+\item{method}{Case insensitive character string : choice of error-propagation method: 1) Gaussian or 2) Monte Carlo).\cr
+Possible values for method are "ga" or "mc".\cr
+The default is "ga" (Gaussian).
+}
+\item{runs}{Number of random samples (for Monte Carlo method only); the default is 10000}
+\item{k1k2}{"l" for using K1 and K2 from Lueker et al. (2000), "m06" from Millero et al. (2006), "m10" from Millero (2010), "w14" from Waters et al. (2014), and "r" from Roy et al. (1993). "x" is the default flag; the default value is then "l", except if T is outside the range 2 to 35oC and/or S is outside the range 19 to 43. In these cases, the default value is "m10".}
+\item{kf}{"pf" for using Kf from Perez and Fraga (1987) and "dg" for using Kf from Dickson and Riley (1979 in Dickson and Goyet, 1994). "x" is the default flag; the default value is then "pf", except if T is outside the range 9 to 33oC and/or S is outside the range 10 to 40. In these cases, the default is "dg".}
+\item{ks}{"d" for using Ks from Dickson (1990) and "k" for using Ks from Khoo et al. (1977), default is "d"}
+\item{pHscale}{"T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
+\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74" }
+\item{gas}{used to indicate the convention for INPUT pCO2, i.e., when it is an input variable (flags 21 to 25): "insitu" indicates it is referenced to in situ pressure and in situ temperature; "potential" indicates it is referenced to 1 atm pressure and potential temperature; and "standard" indicates it is referenced to 1 atm pressure and in situ temperature. All three options should give identical results at surface pressure. This option is not used when pCO2 is not an input variable (flags 1 to 15). The default is "potential".}
+}
+
+\details{
+This subroutine propagates error from input to output variables using one of two methods: 
+\itemize{
+\item Gaussian:
+     The Gaussian method is the standard technique for estimating a computed variable's (z) 
+     second moment (its variance or standard deviation) based on a first-order approximation to z.
+     More precisely, we use here the basic 1st order, 2nd moment uncertainty analysis
+     (a type of Taylor expansion), assuming no covariance between input variables.
+     This is the approach used by Dickson and Riley (1978). It is the default method.
+
+\item Monte Carlo:
+     The Monte Carlo method is a brute-force approach relying on repeated random
+     sampling of input errors, adding those to each input variables, calculating the corresponding 
+     output variables for each sample, and finally assessing the standard deviation in each output variables.
+}
+
+This subroutine has many input parameters that are identical to those
+in the carb() routine. For their details, refer to the 'carb' documentation.
+
+All parameters may be scalars or vectors except epK, method, runs, and gas.\cr
+- method, runs, and gas must be scalars\cr
+- epK must be vector of 7 values: errors of pK0, pK1, pK2, pKb, pKw, pKspa and pKspc;
+    that set of errors is identical for all input data.
+
+In constrast, for evar1, evar2, eS, eT, ePt and eSit,\cr
+- if they are vectors, they represent errors associated with each data point\cr
+- if they are scalars, they represent one error value each associated to all data points
+}
+
+\section{Computation time}{
+  Computation time depends on the method chosen; the Monte Carlo method takes much longer to execute.
+
+  The computational time required for the Monte Carlo method is proportional to the number of runs.
+  More runs, implies improved accuracy:
+     runs = 10000 appears a minimum to obtain an accuracy of less than 1\%.
+     Accuracy is inversely proportional to the number of runs.
+
+  Computation time also depends on the chosen pair of input variables.
+    For example, with the input pair DIC and Alkalinity (flag=15), it is much longer 
+    than for input pair pH and Alkalinity (flag=8)
+}
+
+\value{The function returns a 2-dimensional data-frame, with the folowing columns:
+ \itemize{
+ \item{H}{total error in [H+] concentration  (mol/kg)}
+ \item{pH}{total error in pH}
+ \item{CO2}{total error in CO2 concentration (mol/kg)}
+ \item{pCO2}{total error in "standard" pCO2, CO2 partial pressure computed at in situ temperature and atmospheric pressure (\eqn{\mu}atm)}
+ \item{fCO2}{total error in "standard" fCO2, CO2 fugacity computed at in situ temperature and atmospheric pressure (\eqn{\mu}atm)}
+ \item{HCO3}{total error in HCO3 concentration (mol/kg)}
+ \item{CO3}{total error in CO3 concentration (mol/kg)}
+ \item{DIC}{total error in DIC concentration (mol/kg)}
+ \item{ALK}{total error in ALK, total alkalinity (mol/kg)}
+ \item{OmegaAragonite}{total error in Omega aragonite (aragonite saturation state)}
+ \item{OmegaCalcite}{total error in Omega calcite   (calcite saturation state)}
+}
+ 
+  If all input data have the same 'flag' value, the returned data frame does not show
+errors on input pair of carbonate system variables. For example, if all input
+flags are 15, the input pair is DIC and ALK; hence, errors on DIC and ALK are
+not returned.
+}
+
+\references{
+Dickson, A. G. and Riley, J. P., 1978 The effect of analytical error on the evaluation of the components of the aquatic carbon-dioxide system, Mar. Chem., 6, 77–85.
+
+Dickson A. G. and Riley J. P., 1979 The estimation of acid dissociation constants in seawater media from potentiometric titrations with strong base. I. The ionic product of water. \emph{Marine Chemistry} \bold{7}, 89-99.
+
+Dickson A. G., 1990 Standard potential of the reaction: AgCI(s) + 1/2H2(g) = Ag(s) + HCI(aq), and the standard acidity constant of the ion HSO4 in synthetic sea water from 273.15 to 318.15 K. \emph{Journal of Chemical Thermodynamics} \bold{22}, 113-127.
+
+Dickson A. G., Sabine C. L. and Christian J. R., 2007 Guide to best practices for ocean CO2 measurements. \emph{PICES Special Publication} \bold{3}, 1-191.
+
+Khoo H. K., Ramette R. W., Culberson C. H. and Bates R. G., 1977 Determination of Hydrogen Ion Concentration in Seawater from 5 to 40oC: Standard Potentials at Salinities from 20 to 45. \emph{Analytical Chemistry} \bold{22}, vol49 29-34.
+
+Lee K., Tae-Wook K., Byrne R.H., Millero F.J., Feely R.A. and Liu Y-M, 2010 The universal ratio of the boron to chlorinity for the North Pacific and North Atlantoc oceans. \emph{Geochimica et Cosmochimica Acta} \bold{74} 1801-1811.
+
+Lueker T. J., Dickson A. G. and Keeling C. D., 2000 Ocean pCO2 calculated from dissolved inorganic carbon, alkalinity, and equations for K1 and K2: validation based on laboratory measurements of CO2 in gas and seawater at equilibrium. \emph{Marine Chemistry} \bold{70} 105-119.
+
+Millero F. J., 1995. Thermodynamics of the carbon dioxide system in the oceans. \emph{Geochimica Cosmochimica Acta} \bold{59}: 661-677.
+
+Millero F. J., 2010. Carbonate constant for estuarine waters. \emph{Marine and Freshwater Research} \bold{61}: 139-142.
+
+Millero F. J., Graham T. B., Huang F., Bustos-Serrano H. and Pierrot D., 2006. Dissociation constants of carbonic acid in seawater as a function of salinity and temperature.  \emph{Marine Chemistry} \bold{100}, 80-84.
+
+Orr J. C., Epitalon J.-M. and Gattuso J.-P., 2014. Comparison of seven packages that compute ocean carbonate chemistry. \emph{Biogeosciences Discussions} \bold{11}, 5327-5397.
+
+Perez F. F. and Fraga F., 1987 Association constant of fluoride and hydrogen ions in seawater. \emph{Marine Chemistry} \bold{21}, 161-168.
+
+Roy R. N., Roy L. N., Vogel K. M., Porter-Moore C., Pearson T., Good C. E., Millero F. J. and Campbell D. M., 1993. The dissociation constants of carbonic acid in seawater at salinities 5 to 45 and temperatures 0 to 45oC. \emph{Marine Chemistry} \bold{44}, 249-267.
+
+Uppstrom L.R., 1974 The boron/chlorinity ratio of the deep-sea water from the Pacific Ocean. \emph{Deep-Sea Research I} \bold{21} 161-162.
+
+Waters, J., Millero, F. J., and Woosley, R. J., 2014. Corrigendum to ``The free proton concentration scale for seawater pH'', [MARCHE: 149 (2013) 8-22], Mar. Chem. 165, 66-67.
+
+Weiss, R. F., 1974. Carbon dioxide in water and seawater: the solubility of
+a non-ideal gas, \emph{Mar.  Chem.}, \bold{2}, 203-215.
+
+Weiss, R. F. and Price, B. A., 1980. Nitrous oxide solubility in water and
+seawater, \emph{Mar. Chem.}, \bold{8}, 347-359.
+
+Zeebe R. E. and Wolf-Gladrow D. A., 2001 \emph{CO2 in seawater: equilibrium, kinetics, isotopes}. Amsterdam: Elsevier, 346 pp.
+}
+
+\author{
+Jean-Marie Epitalon, James Orr, and Jean-Pierre Gattuso\email{gattuso@obs-vlfr.fr}
+}
+
+\examples{
+
+## 1) For the input pair ALK and DIC (var1 and var2 when flag=15),
+## compute resulting uncertainty from given uncertainty on ALK and DIC (5 micromol/kg)
+## and default uncertainty in dissociation constants
+## using the default method (Gaussian)
+errors(flag=15, var1=2300e-6, var2=2000e-6, S=35, T=25, P=0, Patm=1.0, 
+       Pt=0, Sit=0, evar1=5e-6, evar2=5e-6, eS=0, eT=0, ePt=0, eSit=0, 
+       pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
+Typical output:
+H	pH	CO2	fCO2	pCO2	HCO3	CO3	OmegaAragonite	OmegaCalcite
+3.721614e-10	0.01796767	5.441869e-07	19.25338	19.31504	9.170116e-06	5.55307e-06	0.1176914	0.1785544
+
+## 2) For the input pair pH and ALK (var1 and var2 when flag=8)
+## compute standard errors in output variables from errors in input variables, i.e., 
+## for pH (0.005 pH units) and in ALK (5 micromol/kg), along with
+## errors in total dissolved inorganic phosphorus (0.1 micromol/kg) and
+## total dissolved inorganic silicon (2 micromol/kg) concentrations, while
+## assuming no uncertainty in dissociation constants, using the Gaussian method:
+errors(flag=8, var1=8.25, var2=2300e-6,  S=35, T=25, P=0, Patm=1.0, 
+       Pt=0, Sit=0, evar1=0.005, evar2=5e-6, eS=0, eT=0, ePt=0.1, eSit=2, 
+       epK=0, method="gaussian", pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
+
+## 3) Use vectors as arguments and compute errors on all output variables
+## using Monte Carlo method taking into account input errors on pH, ALK, DIC
+## and dissociation constants (pKx)
+flag <- c(8, 15, 8)
+var1 <- c(8.2, 0.002394, 8.25)
+var2 <- c(0.002343955, 0.002017, 2400e-6)
+S <- c(35, 35, 30)
+T <- c(25, 25, 22)
+P <- 0
+Pt <- 0
+Sit <- 0
+evar1 <- c(0.005, 2e-6, 0.005)
+evar2 <- c(2e-6, 2e-6, 2e-6)
+epKx <- c(0.002, 0.01, 0.02, 0.01, 0.01, 0.01, 0.01)
+method <- "mc"
+kf <- "pf"
+k1k2 <- "l"
+pHscale <- "T"
+b <- "u74"
+errors(flag=flag, var1=var1, var2=var2, S=S, T=T, P=P, Pt=Pt, Sit=Sit, 
+       evar1=evar1, evar2=evar2, eS=0, eT=0, ePt=0, eSit=0, epK=epKx, 
+       method=method, runs=100000, kf=kf, k1k2=k1k2, pHscale=pHscale, b=b)
+}
+
+\keyword{utilities}


### PR DESCRIPTION
As requested, I have closed my pull request from yesterday (relative to seacarb-git's master branch), and opened a the same pull request but relative to seacarb-git's version-3.1-beta1 branch. Title of pull request and the comments below are essentially the same as before.

New routines have been added to perform error propagation (errors.R) and to take numerical derivatives (derivnum.R) of carb's calculated output variables with respect to its input variables and constants. An existing routine that computes buffer factors (buffesm.R) has been improved.

More specifically, this pull request concerns 2 new routines and 1 improved routine:

1. The `errors.R` routine allows the user to choose to use either the standard approach (Gaussian error propagation) or the Monte Carlo approach. Results of both approaches generally agree within 1% when the argument runs is set to 10 000 (samples).  But the Monte Carlo approach is more computationally intensive, requiring some seconds for each data point even at only runs=10000.  The Gaussian approach is the default.

2. The `derivnum.R` routine is useful not only because it is used in the error propagation (Gassian approach), but also because it computes partial derivatives of all output variables with respect to all input variables and constants; these sensitivities may also be referred to as buffer factors. The numerical approach has been refined to minimize error and its results agree extremely well with available analytical derivatives and mocsy's automatic derivatives which are as accurate as analytical derivatives. Thus the `derivnum` routine has been optimized and tested in many ways.

3. The 'buffesm.R' routine has been improved to account for effects of total dissolved inorganic phospphorus (Pt) and silicon (Sit) on buffer factors and the Revelle factor. This is an advance relative to the original equations from Egleston et al (2010) who did not acount for effects from these nutrients (Orr and Epitalon, 2015).
