### PR TITLE
Now reference Candidate_3.2.4 instead of master, replacing PR#47 (identical changes here)

### DIFF
--- a/R/Kb.R
+++ b/R/Kb.R
@@ -93,9 +93,8 @@ function(S=35,T=25,P=0,pHscale="T",kSWS2scale=0,ktotal2SWS_P0=0,warn="y"){
 
     
     ##------------Warnings
-
     is_w <- warn == "y"
-
+    
     if (any (is_w & (T>45 | S>45 | T<0 | S<5)) ) {warning("S and/or T is outside the range of validity of the formulation available for Kb in seacarb.")}
 
 

--- a/R/Ks.R
+++ b/R/Ks.R
@@ -91,7 +91,7 @@ function(S=35,T=25,P=0, ks="d",warn="y"){
     ##------------Warnings
 
     is_w <- warn == "y"
-
+    
     if (any (is_w & is_k & (T<5 | T>40 | S<20 | S>45)))
         {warning("S and/or T is outside the range of validity of the formulation chosen for Ks.")}
 	

--- a/R/derivnum.R
+++ b/R/derivnum.R
@@ -22,6 +22,7 @@
 #                  case 't', 'temp' or 'temperature' : temperature
 #                  case 's', 'sal' or 'salinity'     : salinity
 #                  case 'K0','K1','K2','Kb','Kw','Kspa' or 'Kspc' : dissociation constant
+#                  case 'bor' : total boron
 #
 #   - others     :  same à input of subroutine  carb() : scalar or vectors
 #
@@ -115,6 +116,35 @@ function(varid, flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0,
         c(1.e-6, 1.e-6),         # flag = 24   
         c(1.e-5, 1.e-5)          # flag = 25   
     )
+
+    # Replace all values of const_deltas (above) with 1e-6 for consistency with CO2SYS-MATLAB
+    const_deltas = rbind (
+        c(1.e-6, 1.e-6),         # flag = 1    
+        c(1.e-6, 1.e-6),         # flag = 2    
+        c(1.e-6, 1.e-6),         # flag = 3    
+        c(1.e-6, 1.e-6),         # flag = 4    
+        c(1.e-6, 1.e-6),         # flag = 5    
+        c(1.e-6, 1.e-6),         # flag = 6    
+        c(1.e-6, 1.e-6),         # flag = 7    
+        c(1.e-6, 1.e-6),         # flag = 8    
+        c(1.e-6, 1.e-6),         # flag = 9    
+        c(1.e-6, 1.e-6),         # flag = 10   
+        c(1.e-6, 1.e-6),         # flag = 11   
+        c(1.e-6, 1.e-6),         # flag = 12   
+        c(1.e-6, 1.e-6),         # flag = 13   
+        c(1.e-6, 1.e-6),         # flag = 14   
+        c(1.e-6, 1.e-6),         # flag = 15   
+        c(0, 0),
+        c(0, 0),
+        c(0, 0),
+        c(0, 0),
+        c(0, 0),
+        c(1.e-6, 1.e-6),         # flag = 21   
+        c(1.e-6, 1.e-6),         # flag = 22   
+        c(1.e-6, 1.e-6),         # flag = 23   
+        c(1.e-6, 1.e-6),         # flag = 24   
+        c(1.e-6, 1.e-6)          # flag = 25   
+    )
     
     # Reference 'concentrations': sorted by flag number
     const_refs  = rbind (
@@ -162,17 +192,17 @@ function(varid, flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0,
     # Initialise absolute deltas
     abs_dx <- rep(NA, n)
 
-    # Uppercase names of dissociation constants
-    K_id <- c('K0', 'K1', 'K2', 'KB', 'KW', 'KSPA', 'KSPC')
+    # Uppercase names of dissociation constants and 'total boron'
+    K_id <- c('K0', 'K1', 'K2', 'KB', 'KW', 'KSPA', 'KSPC', 'BOR')
     # Flag for dissociation constant as perturbed variable 
     flag_dissoc_K = varid %in% K_id
     
     # if perturbed variable is a dissociation constant
     if (flag_dissoc_K)
     {
-        # Approximate values for K0, K1, K2, Kb, Kw, Kspa and Kspc
+        # Approximate values for K0, K1, K2, Kb, Kw, Kspa, Kspc, and bor
         # They will be used to compute an absolute perturbation value on these constants
-        K <- c(0.034, 1.2e-06, 8.3e-10, 2.1e-09, 3.1e-14, 6.7e-07, 4.3e-07)
+        K <- c(0.034, 1.2e-06, 8.3e-10, 2.1e-09, 3.1e-14, 6.7e-07, 4.3e-07, 4.156877e-4)
         # Choose value of absolute perturbation
         index <- which (K_id == varid)
         perturbation = K[index] * 1.e-3   # 0.1 percent of Kx value
@@ -225,7 +255,7 @@ function(varid, flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0,
         var22[GH] = var2[GH] + xref[GH]*delta[GH]
         abs_dx[GH] = var22[GH] - var21[GH]
     }
-    else if (varid %in% c('SIL', 'TSIL', 'SILT', 'SILICATE'))    # Sil total
+    else if (varid %in% c('SIL', 'TSIL', 'SILT', 'SILICATE', 'SIT'))    # Sil total
     {
         # Define relative delta
         delta  = 1.e-3
@@ -237,7 +267,7 @@ function(varid, flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0,
         Sit2 = Sit + Sitref*delta
         abs_dx = Sit2 - Sit1
     }
-    else if (varid %in% c('PHOS', 'TPHOS', 'PHOST', 'PHOSPHATE'))    # Phos total
+    else if (varid %in% c('PHOS', 'TPHOS', 'PHOST', 'PHOSPHATE', 'PT'))    # Phos total
     {
         # Define relative delta
         delta = 1.e-3
@@ -374,7 +404,18 @@ function(varid, flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0,
             # Call original Kspc function
             out <- seacarb::Kspc(S, T, P)
            #out <- Kspc(S, T, P, warn=warn)
-            # perturb value of Kspa
+            # perturb value of Kspc
+            out = out + sign_factor * perturbation  # sign_factor is +1 or -1
+            return (out)
+        }
+    }
+    else if (varid == 'BOR')
+    {
+        bor <- function(S=35,...)
+        {
+            # Call original bor function
+            out <- seacarb::bor(S)
+            # perturb value of bor
             out = out + sign_factor * perturbation  # sign_factor is +1 or -1
             return (out)
         }

--- a/R/derivnum.R
+++ b/R/derivnum.R
@@ -1,13 +1,13 @@
 # derivnum()
 # This subroutine computes partial derivatives of output carbonate variables 
-# with respect to input variables (two), plus nutrients (two), temperature and salinity
+# with respect to input variables (two), plus nutrients (two), temperature and salinity,
 # and dissociation constants.
 #
-# It uses the central difference method, which consists to : 
-# - introduce a small perturbation delta (plus or minus) in one input
-# - and compute the induced delta in output variables
+# It uses the central differences, which consists of  
+# - introducing a small perturbation delta (plus or minus) in one input
+# - and computing the induced delta in output variables
 #
-# The ratio between delta and input value is chosen so : 
+# The ratio between delta and input value is chosen as follows: 
 #    for perturbing input pair :  a constant which depends on the type of input pair of variables.
 #    for perturbing nutrients  :  1.e-6
 #    for perturbing T and S    :  1.e-3

--- a/R/errors.R
+++ b/R/errors.R
@@ -366,8 +366,8 @@ function(flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0, evar1=0, evar2=
     # Salinity and Temperature converted to EOS-80 (if necessary)
     SP    <- rep(NA, n)
     InsT  <- rep(NA, n)
-    
-    # if use of EOS-10 standard
+ 
+    # if use of TEOS-10 standard
     if (eos == "teos10")
     {
         # Must convert temperature and salinity from TEOS-10 to EOS-80

--- a/R/errors.R
+++ b/R/errors.R
@@ -125,9 +125,12 @@ function(flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0,
     neg_eSit <- eSit < 0
     eSit[neg_eSit] <- -eSit[neg_eSit]
     
+    # if eBt=NULL, set eBt equal to zero
+    if(is.null(eBt)) {eBt = 0.0}
+
     # if epK=NULL, set all pK errors to zero
     if(is.null(epK)) {epK = rep(0, 7)}
-
+  
     # Default value for epK
     if (missing(epK))
     {

--- a/man/buffer.Rd
+++ b/man/buffer.Rd
@@ -67,9 +67,9 @@ flag = 25     pCO2 and DIC given
 	\item{pHscale}{choice of pH scale: "T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
  	\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74" }
   \item{warn}{"y" to show warnings when T or S go beyond the valid range for constants; "n" to supress warnings. The default is "y".}
-    \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+    \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 

--- a/man/buffesm.Rd
+++ b/man/buffesm.Rd
@@ -67,9 +67,9 @@ flag = 25     pCO2 and DIC given
 	\item{pHscale}{choice of pH scale: "T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
 	\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74" }
         \item{warn}{"y" to show warnings when T or S go beyond the valid range for constants; "n" to supress warnings. The default is "y".}
-        \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-        \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-        \item{lat}{latitude of data point, used when eos parameter is "teos".}
+        \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+        \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+        \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 

--- a/man/buffesm.Rd
+++ b/man/buffesm.Rd
@@ -2,7 +2,7 @@
 \name{buffesm}
 \alias{buffesm}
 %- Also NEED an '\alias' for EACH other topic documented here.
-\title{Buffer capacities of the seawater carbonate system as defined by Egleston et al. (2010)}
+\title{Buffer capacities of the seawater carbonate system from Egleston et al. (2010), corrected and enhanced}
 \description{Returns the six buffer factors of the seawater carbonate system as defined by Egleston, Sabine and Morel (2010), denoted here as ESM. Also returns the classic Revelle factor (relative change in pCO2 over that for DIC). In ESM, there are errors in the equations in Table 1 for \eqn{S}, \eqn{\Omega_{DIC}}, and \eqn{\Omega_{Alk}}. These errors have been corrected here.  The results of this routine have been validated: when input concentrations of Pt and Sit are set to zero, they produce results that are identical to those shown in ESM's Fig. 2. But when Pt and Sit are nonzero, contributions from phosphoric and silicic acid systems are taken into account, an improvement to the Egleston et al. (2010) approach. This routine was inspired and adapted from seacarb's ``buffer'' function. Its input arguments are indentical to those in the ``buffer'' and ``carb'' functions of seacarb.}
 \usage{
 buffesm(flag, var1, var2, S = 35, T = 25, Patm = 1, P = 0, Pt = 0, Sit = 0, 
@@ -66,10 +66,10 @@ flag = 25     pCO2 and DIC given
 	\item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"} 
 	\item{pHscale}{choice of pH scale: "T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
 	\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74" }
-  \item{warn}{"y" to show warnings when T or S go beyond the valid range for constants; "n" to supress warnings. The default is "y".}
-    \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+        \item{warn}{"y" to show warnings when T or S go beyond the valid range for constants; "n" to supress warnings. The default is "y".}
+        \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
+        \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
+        \item{lat}{latitude of data point, used when eos parameter is "teos".}
 }
 
 

--- a/man/carbb.Rd
+++ b/man/carbb.Rd
@@ -67,9 +67,9 @@ flag = 25     pCO2 and DIC given
   \item{gas}{used to indicate the convention for INPUT pCO2, i.e., when it is an input variable (flags 21 to 25): "insitu" indicates it is referenced to in situ pressure and in situ temperature; "potential" indicates it is referenced to 1 atm pressure and potential temperature; and "standard" indicates it is referenced to 1 atm pressure and in situ temperature. All three options should give identical results at surface pressure. This option is not used when pCO2 is not an input variable (flags 1 to 15). The default is "potential".}
   \item{badd}{Amount of boron added in mol/kg.}
   \item{warn}{"y" to show warnings when T or S go beyond the valid range for constants; "n" to supress warnings. The default is "y".}
-  \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+  \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{The Lueker et al. (2000) constants for K1 and K2, the Perez and Fraga (1987) constant for Kf and the Dickson (1990) constant for Ks are recommended by Dickson et al. (2007). It is, however, critical to consider that each formulation is only valid for specific ranges of temperature and salinity:

--- a/man/derivnum.Rd
+++ b/man/derivnum.Rd
@@ -2,7 +2,7 @@
 \name{derivnum}
 \alias{derivnum}
 \title{Numerical derivatives of seawater carbonate system variables}
-\description{Returns numerical derivatives  of the seawater carbonate system putput variables with respect to input variables.}
+\description{Returns numerical derivatives of the seawater carbonate system output variables with respect to input variables.}
 \usage{derivnum(varid, flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0,
        k1k2="x", kf="x", ks="d", pHscale="T", b="u74", gas="potential", warn="y", 
        eos = "eos80", long = 1e+20, lat = 1e+20)}
@@ -22,8 +22,13 @@ Possible values are:
 't', 'temp' or 'temperature' : temperature
 
 's', 'sal' or 'salinity'     : salinity
+
+'K0','K1','K2','Kb','Kw','Kspa' or 'Kspc' : one of the dissociation constants
+
+'bor' : total boron
 }
-\item{flag}{select the couple of variables available. The flags which can be used are:
+\item{flag}{select the input pair of carbonate-system variables
+  available by choosing the following flag:
 
 flag = 1      pH and CO2 given
 

--- a/man/derivnum.Rd
+++ b/man/derivnum.Rd
@@ -85,9 +85,9 @@ flag = 25     pCO2 and DIC given
 \item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74" }
  \item{gas}{used to indicate the convention for INPUT pCO2, i.e., when it is an input variable (flags 21 to 25): "insitu" indicates it is referenced to in situ pressure and in situ temperature; "potential" indicates it is referenced to 1 atm pressure and potential temperature; and "standard" indicates it is referenced to 1 atm pressure and in situ temperature. All three options should give identical results at surface pressure. This option is not used when pCO2 is not an input variable (flags 1 to 15). The default is "potential".}
   \item{warn}{"y" to show warnings when T or S go beyond the valid range for constants; "n" to supress warnings. The default is "y".}
-    \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+    \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{

--- a/man/errors.Rd
+++ b/man/errors.Rd
@@ -68,15 +68,16 @@ flag = 25     pCO2 and DIC given
 \item{P}{Hydrostatic pressure in bar (surface = 0)}
 \item{Pt}{Concentration of total dissolved inorganic phosphorus (mol/kg); set to 0 if NA}
 \item{Sit}{Concentration of total dissolved inorganic silicon (mol/kg); set to 0 if NA}
-\item{evar1}{Standard error (uncertainty) in var1 of input pair of carbonate system variables}
-\item{evar2}{Standard error (uncertainty) in var2 of input pair of carbonate system variables}
-\item{eS}{Standard error (uncertainty) in salinity; default is 0.01}
-\item{eT}{Standard error (uncertainty) in temperature (degree C); default is 0.01}
-\item{ePt}{Standard error (uncertainty) in total dissolved inorganic phosphorus concentration (mol/kg)}
-\item{eSit}{Standard error (uncertainty)in total dissolved inorganic silicon concentration (mol/kg)}
-\item{epK}{Standard error (uncertainty) in 7 key dissociation constants: pK0, pK1, pK2, pKb, pKw, pKspa and pKspc. This is a vector. The default is c(0.004, 0.015, 0.03, 0.01, 0.01, 0.02, 0.02).)
-\item{eBt}{Standard error (uncertainty)in total boron, given as a relative fractional error (0.01 is a 1\% error}
-\item{method}{Case insensitive character string : choice of error-propagation method: 1) Gaussian, 
+\item{evar1}{Error (uncertainty) in var1 of input pair of carbonate system variables}
+\item{evar2}{Error (uncertainty) in var2 of input pair of carbonate system variables}
+\item{eS}{Error (uncertainty) in salinity; default is 0.01}
+\item{eT}{Error (uncertainty) in temperature (degree C); default is 0.01}
+\item{ePt}{Error (uncertainty) in total dissolved inorganic phosphorus concentration (mol/kg)}
+\item{eSit}{Error (uncertainty) in total dissolved inorganic silicon concentration (mol/kg)}
+\item{epK}{Error (uncertainty) in 7 key dissociation constants: pK0, pK1, pK2, pKb, pKw, pKspa and pKspc. This is a vector. The default is c(0.004, 0.015, 0.03, 0.01, 0.01, 0.02, 0.02).)
+\item{eBt}{Error (uncertainty) in total boron, given as a
+  relative fractional error. The default is 0.01, which equates to a 1\% error}
+\item{method}{Case insensitive character string to choose the error-propagation method: 1) Gaussian, 
 2) Method of Moments, or 3) Monte Carlo).\cr
 These methods are specified using the 2-letter codes "ga", "mo", or "mc", respectively. The default is "ga" (Gaussian).}
 \item{r}{Correlation coefficient between uncertainties of var1 and var2 (only useful with method="mo",
@@ -89,13 +90,27 @@ i.e., ignored for the 2 other methods, the default is r=0.0}
 \item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74" }
 \item{gas}{used to indicate the convention for INPUT pCO2, i.e., when it is an input variable (flags 21 to 25): "insitu" indicates it is referenced to in situ pressure and in situ temperature; "potential" indicates it is referenced to 1 atm pressure and potential temperature; and "standard" indicates it is referenced to 1 atm pressure and in situ temperature. All three options should give identical results at surface pressure. This option is not used when pCO2 is not an input variable (flags 1 to 15). The default is "potential".}
 \item{warn}{"y" to show warnings when T or S go beyond the valid range for constants; "n" to supress warnings. The default is "y".}
-\item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-\item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-\item{lat}{latitude of data point, used when eos parameter is "teos".}
+\item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+\item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+\item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{
-This function propagates error from input to output variables using one of three methods: 
+This function requires users to specify each input uncertainty as either
+the standard deviation or the standard error of the mean. The latter
+implies much smaller propagated uncertainties, but is appropriate only
+when interested in the error in the mean, not the error of a given
+measurement. Beware that it is easy to fool oneself when using the
+standard error of the mean rather than the standard deviation.
+
+This function requires different types of uncertainties:
+\itemize{
+\item absolute uncertainties for evar1, evar2, eS, eT, ePt, eSit (same units as the input data, e.g., mol/kg);
+\item uncertainties in pK units for epK; and
+\item uncertainties in relative fractional units (between 0.0 and 1.0) for eBt.
+}
+
+This function propagates uncertainties from input to output variables using one of three methods: 
 \itemize{
 \item Gaussian:
      The Gaussian method is the standard technique for estimating a
@@ -229,7 +244,7 @@ Jean-Marie Epitalon, James Orr, and Jean-Pierre Gattuso\email{gattuso@obs-vlfr.f
 
 ## 1) For the input pair ALK and DIC (var1 and var2 when flag=15),
 ## compute resulting uncertainty from given uncertainty on ALK and DIC (5 umol/kg)
-## and default uncertainty in dissociation constants
+## and default uncertainties in dissociation constants and total boron
 ## using the default method (Gaussian)
 errors(flag=15, var1=2300e-6, var2=2000e-6, S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0, 
        evar1=5e-6, evar2=5e-6, eS=0, eT=0, ePt=0, eSit=0, 
@@ -261,7 +276,7 @@ errors(flag=8, var1=8.25, var2=2300e-6,  S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0,
 ## nor in the dissociation constants BUT a perfect anticorrelation between pCO2 and pH,
 ## (the input pair) using the Method of moments:
 errors(flag=21, var1=400, var2=8.1,  S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0, 
-       evar1=2, evar2=0.005, eS=0, eT=0, ePt=0.0, eSit=0, epK=0, 
+       evar1=2, evar2=0.005, eS=0, eT=0, ePt=0.0, eSit=0, epK=0, eBt=0, 
        method="mo", r=-1.0, pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
 
 ## 5) Use vectors as arguments and compute errors on all output variables
@@ -278,7 +293,7 @@ Sit <- 0
 evar1 <- c(0.005, 2e-6, 0.005)
 evar2 <- c(2e-6, 2e-6, 2e-6)
 epKx <- c(0.002, 0.01, 0.02, 0.01, 0.01, 0.01, 0.01)
-eBtx = 0.02
+eBtx = 0.01
 method <- "mc"
 kf <- "pf"
 k1k2 <- "l"

--- a/man/errors.Rd
+++ b/man/errors.Rd
@@ -5,12 +5,14 @@
 \description{Estimates uncertainties in computed carbonate system variables by propagating standard error (uncertainty) in six input variables, including
   * the input pair of carbonate system variables, 
   * the 2 input nutrients (silicate and phosphate concentrations),
-  * temperature and salinity, as well as
-the errors in the key dissociation constants pK0, pK1, pK2, pKb, pKw, pKspa and pKspc
+  * temperature and salinity. It also accounts for
+  * the errors in the key dissociation constants pK0, pK1, pK2, pKb, pKw, pKspa and pKspc, as well as
+  * the error in total boron.
 }
 \usage{errors(flag, var1, var2, S=35, T=25, Patm=1, P=0, Pt=0, Sit=0, 
               evar1=0, evar2=0, eS=0.01, eT=0.01, ePt=0, eSit=0, 
-              epK=c(0.002, 0.01, 0.02, 0.01, 0.01, 0.02, 0.02), 
+              epK=c(0.004, 0.015, 0.03, 0.01, 0.01, 0.02, 0.02),
+              eBt=0.01,
               method = "ga", r=0.0, runs=10000,
               k1k2='x', kf='x', ks="d", pHscale="T", b="u74", gas="potential", 
               warn="y", eos = "eos80", long = 1e+20, lat = 1e+20)}
@@ -72,7 +74,8 @@ flag = 25     pCO2 and DIC given
 \item{eT}{Standard error (uncertainty) in temperature (degree C); default is 0.01}
 \item{ePt}{Standard error (uncertainty) in total dissolved inorganic phosphorus concentration (mol/kg)}
 \item{eSit}{Standard error (uncertainty)in total dissolved inorganic silicon concentration (mol/kg)}
-\item{epK}{Standard error (uncertainty) in 7 key dissociation constants: pK0, pK1, pK2, pKb, pKw, pKspa and pKspc. This is a vector. The default is 0.002, 0.01, 0.02, 0.01, 0.01, 0.01 and 0.01.}
+\item{epK}{Standard error (uncertainty) in 7 key dissociation constants: pK0, pK1, pK2, pKb, pKw, pKspa and pKspc. This is a vector. The default is c(0.004, 0.015, 0.03, 0.01, 0.01, 0.02, 0.02).)
+\item{eBt}{Standard error (uncertainty)in total boron, given as a relative fractional error (0.01 is a 1\% error}
 \item{method}{Case insensitive character string : choice of error-propagation method: 1) Gaussian, 
 2) Method of Moments, or 3) Monte Carlo).\cr
 These methods are specified using the 2-letter codes "ga", "mo", or "mc", respectively. The default is "ga" (Gaussian).}
@@ -124,11 +127,12 @@ This function propagates error from input to output variables using one of three
 This function has many input parameters that are identical to those
 in the carb function. For their details, refer to the 'carb' documentation.
 
-All parameters may be scalars or vectors except epK, method, runs, and gas.
+All parameters may be scalars or vectors except epK, eBt, method, runs, and gas.
 
 \itemize{
-  \item method, runs, and gas must be scalars
-  \item epK must be vector of 7 values. It must list errors for 
+  \item runs and eBt must be scalars
+  \item method and gas must each consist of a character string
+  \item epK may be a vector of 7 values. In that case, it must list errors for 
     pK0, pK1, pK2, pKb, pKw, pKspa and pKspc, respectively.
     That set of errors is identical for all input data.
     Alternatively, users may specify 'epK=NULL' or 'epK=0' to set all 7 values to zero
@@ -234,17 +238,24 @@ errors(flag=15, var1=2300e-6, var2=2000e-6, S=35, T=25, P=0, Patm=1.0, Pt=0, Sit
 ## H             pH          CO2           fCO2      pCO2      HCO3          ...
 ## 3.721614e-10  0.01796767  5.441869e-07  19.25338  19.31504  9.170116e-06  ...
 
-## 2) For the input pair pH and ALK (var1 and var2 when flag=8)
+## 2) Do the same as in one, but assign a 4% uncertainty to total boron
+##    This uncertainty is the amount by which estimates from Lee et al (2010) and 
+##    Uppstrom (1974) differ. The default for the latter is eBt=0.01.
+errors(flag=15, var1=2300e-6, var2=2000e-6, S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0, 
+       evar1=5e-6, evar2=5e-6, eS=0, eT=0, ePt=0, eSit=0, eBt=0.04,
+       pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
+
+## 3) For the input pair pH and ALK (var1 and var2 when flag=8)
 ## compute standard errors in output variables from errors in input variables, i.e., 
 ## for pH (0.005 pH units) and in ALK (5 umol/kg), along with
 ## errors in total dissolved inorganic phosphorus (0.1 umol/kg) and
 ## total dissolved inorganic silicon (2 umol/kg) concentrations, while
-## assuming no uncertainty in dissociation constants, using the Gaussian method:
+## assuming no uncertainty in dissociation constants & boron, using the Gaussian method:
 errors(flag=8, var1=8.25, var2=2300e-6,  S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0, 
-       evar1=0.005, evar2=5e-6, eS=0, eT=0, ePt=0.1, eSit=2, epK=0, 
+       evar1=0.005, evar2=5e-6, eS=0, eT=0, ePt=0.1, eSit=2, epK=0, eBt=0,
        method="ga", pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
 
-## 3) For the input pair pCO2 and pH (var1 and var2 when flag=21)
+## 4) For the input pair pCO2 and pH (var1 and var2 when flag=21)
 ## compute standard errors in output variables from errors in input variables, i.e., 
 ## for pCO2 (2 uatm) and pH (0.005 pH units), with no uncertainties in Pt and Sit
 ## nor in the dissociation constants BUT a perfect anticorrelation between pCO2 and pH,
@@ -253,7 +264,7 @@ errors(flag=21, var1=400, var2=8.1,  S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0,
        evar1=2, evar2=0.005, eS=0, eT=0, ePt=0.0, eSit=0, epK=0, 
        method="mo", r=-1.0, pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
 
-## 4) Use vectors as arguments and compute errors on all output variables
+## 5) Use vectors as arguments and compute errors on all output variables
 ## using Monte Carlo method taking into account input errors on pH, ALK, DIC
 ## and dissociation constants (pKx)
 flag <- c(8, 15, 8)
@@ -267,6 +278,7 @@ Sit <- 0
 evar1 <- c(0.005, 2e-6, 0.005)
 evar2 <- c(2e-6, 2e-6, 2e-6)
 epKx <- c(0.002, 0.01, 0.02, 0.01, 0.01, 0.01, 0.01)
+eBtx = 0.02
 method <- "mc"
 kf <- "pf"
 k1k2 <- "l"
@@ -276,7 +288,7 @@ b <- "u74"
 ## because it takes too long to run when submiting to CRAN
 ## and is therefore rejected
 \donttest{errors(flag=flag, var1=var1, var2=var2, S=S, T=T, P=P, Pt=Pt, Sit=Sit, 
-       evar1=evar1, evar2=evar2, eS=0, eT=0, ePt=0, eSit=0, epK=epKx, 
+       evar1=evar1, evar2=evar2, eS=0, eT=0, ePt=0, eSit=0, epK=epKx, eBt=eBtx,
        method=method, runs=10000, kf=kf, k1k2=k1k2, pHscale=pHscale, b=b)}
 }
 

--- a/man/oa.Rd
+++ b/man/oa.Rd
@@ -66,9 +66,9 @@ flag = 25     pCO2 and DIC given
 	\item{pHscale}{"T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
 	\item{plot}{A plot of the different perturbation methods can be plotted in a DIC vs ALK field with pCO2 isoclines are drawn in the back. Default is false.}
 	\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74".}
-	 \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+	 \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{The Lueker et al. (2000) constants for K1 and K2, the Perez and Fraga (1987) constant for Kf and the Dickson (1990) constant for Ks are recommended by Dickson et al. (2007). It is, however, critical to consider that each formulation is only valid for specific ranges of temperature and salinity:

--- a/man/pCa.Rd
+++ b/man/pCa.Rd
@@ -65,9 +65,9 @@ flag = 25     pCO2 and DIC given
 	\item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"} 
 	\item{pHscale}{choice of pH scale: "T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
 	\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74".}
-	  \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+	  \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{The Lueker et al. (2000) constants for K1 and K2, the Perez and Fraga (1987) constant for Kf and the Dickson (1990) constant for Ks are recommended by Dickson et al. (2007). It is, however, critical to consider that each formulation is only valid for specific ranges of temperature and salinity:

--- a/man/pHinsi.Rd
+++ b/man/pHinsi.Rd
@@ -22,9 +22,9 @@ pHinsi(pH=8.2, ALK=2.4e-3, Tinsi=20, Tlab=25, S=35, Pt=0, Sit=0,
   \item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"} 
   \item{pHscale}{choice of pH scale: "T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
   \item{b}{"l10" for computing boron total from the Lee et al. (2010) formulation or "u74" for using the Uppstrom (1974) formulation, default is "u74" }
-    \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+    \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \value{

--- a/man/pTA.Rd
+++ b/man/pTA.Rd
@@ -69,9 +69,9 @@ flag = 25     pCO2 and DIC given
 	\item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"} 
 	\item{pHscale}{"T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
 	\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74".}
-	  \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+	  \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 

--- a/man/pgas.Rd
+++ b/man/pgas.Rd
@@ -65,9 +65,9 @@ flag = 25     pCO2 and DIC given
 	\item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"} 
 	\item{pHscale}{"T" for the total scale, "F" for the free scale and "SWS" for using the seawater scale, default is "T" (total scale)}
 	\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74".}
-	  \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+	  \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{The Lueker et al. (2000) constants for K1 and K2, the Perez and Fraga (1987) constant for Kf and the Dickson (1990) constant for Ks are recommended by Dickson et al. (2007). It is, however, critical to consider that each formulation is only valid for specific ranges of temperature and salinity:

--- a/man/pmix.Rd
+++ b/man/pmix.Rd
@@ -66,9 +66,9 @@ flag = 25     pCO2 and DIC given
 	\item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"} 
 	\item{pHscale}{choice of pH scale: "T" for using the total scale, "F" for using the free scale and "SWS" for using the seawater scale, default is total scale}
 	\item{b}{Concentration of total boron. "l10" for the Lee et al. (2010) formulation or "u74" for the Uppstrom (1974) formulation, default is "u74".}
-	  \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+	  \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{The Lueker et al. (2000) constants for K1 and K2, the Perez and Fraga (1987) constant for Kf and the Dickson (1990) constant for Ks are recommended by Dickson et al. (2007). It is, however, critical to consider that each formulation is only valid for specific ranges of temperature and salinity:

--- a/man/ppH.Rd
+++ b/man/ppH.Rd
@@ -68,9 +68,9 @@ flag = 25     pCO2 and DIC given
   	\item{kf}{"pf" for using Kf from Perez and Fraga (1987) and "dg" for using Kf from Dickson and Riley (1979 in Dickson and Goyet, 1994). "x" is the default flag; the default value is then "pf", except if T is outside the range 9 to 33oC and/or S is outside the range 10 to 40. In these cases, the default is "dg".}
 	\item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"} 
 	\item{pHscale}{choice of pH scale: "T" for using the total scale, "F" for using the free scale and "SWS" for using the seawater scale, default is total scale}
-	  \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+	  \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{The Lueker et al. (2000) constants for K1 and K2, the Perez and Fraga (1987) constant for Kf and the Dickson (1990) constant for Ks are recommended by Dickson et al. (2007). It is, however, critical to consider that each formulation is only valid for specific ranges of temperature and salinity:

--- a/man/psi.Rd
+++ b/man/psi.Rd
@@ -64,9 +64,9 @@ flag = 25     pCO2 and DIC given
         \item{k1k2}{"l" for using K1 and K2 from Lueker et al. (2000), "m06" from Millero et al. (2006), "m10" from Millero (2010), "w14" from Waters et al. (2014), and "r" from Roy et al. (1993). "x" is the default flag; the default value is then "l", except if T is outside the range 2 to 35oC and/or S is outside the range 19 to 43. In these cases, the default value is "w14".}
   \item{kf}{"pf" for using Kf from Perez and Fraga (1987) and "dg" for using Kf from Dickson and Riley (1979 in Dickson and Goyet, 1994). "x" is the default flag; the default value is then "pf", except if T is outside the range 9 to 33oC and/or S is outside the range 10 to 40. In these cases, the default is "dg".}
 	\item{ks}{"d" for using Ks from Dickon (1990), "k" for using Ks from Khoo et al. (1977), default is "d"}
-	  \item{eos}{"teos" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos" to specify T and S according to EOS-80.}
-  \item{long}{longitude of data point, used when eos parameter is "teos" as a conversion parameter from absolute to practical salinity.}
-  \item{lat}{latitude of data point, used when eos parameter is "teos".}
+	  \item{eos}{"teos10" to specify T and S according to Thermodynamic Equation Of Seawater - 2010 (TEOS-10); "eos80" to specify T and S according to EOS-80.}
+  \item{long}{longitude of data point, used when eos parameter is "teos10" as a conversion parameter from absolute to practical salinity.}
+  \item{lat}{latitude of data point, used when eos parameter is "teos10".}
 }
 
 \details{The Lueker et al. (2000) constants for K1 and K2, the Perez and Fraga (1987) constant for Kf and the Dickson (1990) constant for Ks are recommended by Dickson et al. (2007). It is, however, critical to consider that each formulation is only valid for specific ranges of temperature and salinity:


### PR DESCRIPTION
@jpgattuso

I've just closed Pull Request #47 (relative to your master branch) and issued a new request for the same changes but relative to your **Canditate_3.2.4** branch.

Here again is a brief global view of the changes (not all inclusive). Changes were made to *errors.R* and *derivnum.R** so that the user can specify the error on total boron (**eBt**) as a separate argument when calculating errors and so that seacarb users employ the latest defaults in the **epK** vector

The option to account for the error in total boron was offered in a previous pull request. Eventually though, you felt it was inappropriate to include that error at the end of the epK vector ('bor' is not an equilibrium constant after all). As a result, the current version of errors.R seacarb does not propagate any error for total boron. That deficiency would be remedied if you would accept this pull request. With this update, when calling errors.R, the user would specify the epK vector and eBt separately; otherwise the user accepts their defaults.

I've also changed the defaults for the epK vector (7 values for the 7 equil. constants) to those used in the most recent version of our manuscript. They have increased for K0, K1, and K2, following recommendations from A. Dickson (accounting for random and systematic errors). The updated valules are the same as specified in our Table 1. Likewise they are identical to the values used in the 3 other packages.

The corresponding documentation (.Rd files) have also been updated accordingly.

Thanks!
