### PR TITLE
Fix typos in SeaFET functions

### DIFF
--- a/R/sf_calc.R
+++ b/R/sf_calc.R
@@ -15,12 +15,12 @@ nK <- max(length(calEint), length(calEext), length(E0int25), length(E0ext25), le
 
     ##-------- Creation de vecteur pour toutes les entrees (si vectorielles)
     
-    if(length(calEint)!=nK){S <- rep(S[1], nK)}
-    if(length(calEext)!=nK){T <- rep(T[1], nK)}
-    if(length(E0int25)!=nK){P <- rep(P[1], nK)}
-    if(length(E0ext25)!=nK){P <- rep(P[1], nK)}
-    if(length(calT)!=nK){P <- rep(P[1], nK)}
-    if(length(calSal)!=nK){P <- rep(P[1], nK)}
+    if(length(calEint)!=nK){calEint <- rep(S[1], nK)}
+    if(length(calEext)!=nK){calEext <- rep(T[1], nK)}
+    if(length(E0int25)!=nK){E0int25 <- rep(P[1], nK)}
+    if(length(E0ext25)!=nK){E0ext25 <- rep(P[1], nK)}
+    if(length(calT)!=nK){calT <- rep(P[1], nK)}
+    if(length(calSal)!=nK){calSal <- rep(P[1], nK)}
     
     # --------------------- sf_calc ----------------------------
     

--- a/R/sf_calib.R
+++ b/R/sf_calib.R
@@ -15,11 +15,11 @@ nK <- max(length(calEint), length(calEext), length(calpH), length(calT), length(
 
     ##-------- Creation de vecteur pour toutes les entrees (si vectorielles)
     
-    if(length(calEint)!=nK){S <- rep(S[1], nK)}
-    if(length(calEext)!=nK){T <- rep(T[1], nK)}
-    if(length(calpH)!=nK){P <- rep(P[1], nK)}
-    if(length(calT)!=nK){P <- rep(P[1], nK)}
-    if(length(calSal)!=nK){P <- rep(P[1], nK)}
+    if(length(calEint)!=nK){calEint <- rep(S[1], nK)}
+    if(length(calEext)!=nK){calEext <- rep(T[1], nK)}
+    if(length(calpH)!=nK){calpH <- rep(P[1], nK)}
+    if(length(calT)!=nK){calT <- rep(P[1], nK)}
+    if(length(calSal)!=nK){calSal <- rep(P[1], nK)}
     
     # --------------------- sf_calib ----------------------------
     


### PR DESCRIPTION
The first lines in the seaFET functions refer to variables which do not exist in the functions. I corrected these so that these lines would work as intended. 

I first came across the issue when I tried to calibrate SeaFET data using a single E0_25. The error I got was a strange one ("Object P not found"), which led me to look into these functions. 