### PR TITLE
Better specification of functions arguments

### DIFF
--- a/man/rho.Rd
+++ b/man/rho.Rd
@@ -9,8 +9,8 @@ rho(S = 35, T = 25, P = 0)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
-  \item{S}{Salinity, default is 35}
-  \item{T}{Temperature in degrees Celsius, default is 25oC}
+  \item{S}{Practical Salinity (PSS-78), default is 35}
+  \item{T}{Temperature in degrees Celsius (ITS-90), default is 25oC}
   \item{P}{Hydrostatic pressure in bar (surface = 0), default is 0}
 }
 


### PR DESCRIPTION
Original reference Millero & Poisson 1981 use IPTS-68 temperature scale. Not clear from the documentation that you input ITS-90 temperature and the function then converts to IPTS-68 for the calculation unless you look 'under the hood' at the function.

Specify Practical Salinity to differentiate from functions that require Absolute Salinity?