### PR TITLE
Jens

### DIFF
--- a/R/pHspec.R
+++ b/R/pHspec.R
@@ -1,0 +1,112 @@
+# Copyright (C) 2009 Jean-Pierre Gattuso
+# Copyright (C) 2018 Jens Daniel Mueller, update
+#
+# This file is part of seacarb.
+#
+# Seacarb is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or any later version.
+#
+# Seacarb is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with seacarb; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+"pHspec" <-
+function(S=35, T=25, R=1, d="mCP", k="m18", warn="y")
+  {
+  #-------Harmonize input vector length-----
+  
+  n <- max(length(S), length(T), length(d), length(k))
+  
+  if(length(S)!=n){S <- rep(S[1],n)}
+  if(length(T)!=n){T <- rep(T[1],n)}
+  if(length(R)!=n){R <- rep(T[1],n)}
+  if(length(d)!=n){d <- rep(d[1],n)}
+  if(length(k)!=n){k <- rep(k[1],n)}
+
+
+  #-------Initialise output vector------- 
+  
+  pHspec <- rep(NA, n)
+  method <- rep(NA, n)
+  
+  #-------Change temperature scale from [deg C] to [K] ----
+  
+  TK = T + 273.15;           # T [C]; TK [K]
+  
+  #-------Calculate sample pH based on input values-------
+  
+ 	#--------------------------------------------------------------
+	#-------mCP characterization by Mueller and Rehder 2018-----------
+	#
+	#       https://doi.org/10.3389/fmars.2018.00177  
+	#     
+	#       Calculates pH of seawater, brackish, and freshwater samples
+	#       based on absorbance ratios R obtained from spectrophotometric 
+	#       measurements with the dye m-Cresol purple 
+	#
+	#       pH-scale: total scale
+	#        
+	#       correct for T range : 5 - 35 °C
+	#       correct for S range : 0 - 40
+	#--------------------------------------------------------------
+	
+  pHspec_m18 <-
+    
+    #firsTK seTK of coefficienTKs defines pK2e2 = f(Sal, TKem)
+    
+    1.08071477e+03                      -
+    1.35394946e-01  *S^0.5            -   
+    1.98063716e+02  *S^1.5            +
+    6.31924397e+01  *S^2              -
+    5.18141866e+00  *S^2.5            -
+    2.66457425e+04  *TK^-1             +
+    5.08796578e+03  *S^1.5 * TK^-1   -
+    1.62454827e+03  *S^2 * TK^-1     +
+    1.33276788e+02  *S^2.5 * TK^-1   -
+    1.89671212e+02  *log(TK)           +
+    3.49038762e+01  *S^1.5 * log(TK) -
+    1.11336508e+01  *S^2 * log(TK)   +
+    9.12761930e-01  *S^2.5 * log(TK) +
+    3.27430677e-01  *TK              -
+    7.51448528e-04  *S^0.5 * TK      +
+    3.94838229e-04  *S * TK          -
+    6.00237876e-02  *S^1.5 * TK      +
+    1.90997693e-02  *S^2 * TK        -
+    1.56396488e-03  *S^2.5 * TK      +
+    
+    #second seTK of coefficienTKs includes TKhe definiTKion of mCP absorpTKiviTKy raTKios e1 and e3/e3
+    #as deTKermined by Liu eTK al. (2011) and defines TKhe log-TKerm calculaTKion 
+    
+    log10(
+      (R -
+         (-0.007762 + 4.5174e-5*TK)) /
+        (1 - (R *  (- 0.020813 + 2.60262e-4*TK + 1.0436e-4*(S-35))))
+    )
+  
+  
+  
+	
+  #-------------------------------------------------------------------
+	#-------Choose between mCP characterizations (=method)----------
+	
+  is_m18 <- (k=='m18')
+	pHspec[is_m18] <- pHspec_m18[is_m18]
+	
+	#-------Assign method -------------------
+	
+  method[is_m18] <- "Mueller and Rehder (2018)"
+	
+	#-------Set warnings-----------
+	is_w <- warn == "y"
+	if (any(is_w & is_m18 & (T>35 | T<5 | S>40))) 
+	  {warning("S, and/or T is outside the range of validity for the mCP characterization by Mueller and Rehder (2018).")}
+	
+	#-------Assign attributes and define return value-----------
+	
+	attr(pHspec, "method") = method
+	attr(pHspec, "pH scale") = "total scale"
+	attr(pHspec,"unit") <- "mol/kg-soln"
+	return(pHspec)
+
+}
+

--- a/R/tris.R
+++ b/R/tris.R
@@ -1,4 +1,5 @@
-# Copyright (C) 2009 Jean-Pierre Gattuso, 2018 updated by Jens Daniel Mueller
+# Copyright (C) 2009 Jean-Pierre Gattuso
+# Copyright (C) 2018 updated by Jens Daniel Mueller
 #
 # This file is part of seacarb.
 #
@@ -12,11 +13,10 @@
 
 "tris" <-
 function(S=35, T=25, k="m18", b=0.04, warn="y")
-  
+
   {
   
-  
-  #-------Harmonize input vectors to identical length-------
+  #-------Harmonize input vector length-----
   
   n <- max(length(S), length(T), length(k), length(b))
   
@@ -25,18 +25,13 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
   if(length(k)!=n){k <- rep(k[1],n)}
   if(length(b)!=n){b <- rep(b[1],n)}
 
-  
   #-------Initialise output vector------- 
   
   tris <- rep(NA, n)
   
+  #-------Change temperature scale from [°C] to [K] ----
   
-  #---- changing temperature scale from Celsius to Kelvin ----
-  
-  tk = 273.15;           # [K] (for conversion [deg C] <-> [K])
-  TK = T + tk;           # T [C]; TK [K]
-  
-  
+  TK = T + 273.15;           # T [C]; TK [K]; [K] (for conversion [deg C] <-> [K])
   
   #-------calculate tris buffer pH based on input-------
   

--- a/R/tris.R
+++ b/R/tris.R
@@ -108,19 +108,19 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
 	
 	  #-------Assign method -------------------
 	
-	  method <- rep(NA, nK)
+	  method <- rep(NA, n)
 	  method[!is_d] <- "Mueller et al. (2018)"
 	  method[is_d] <- "DelValls and Dickson (1998)"
 	
 	  #-------Set warnings-----------
 	
 	  is_w <- warn == "y"
-	  
-	  # if (any(is_w & (T>35 | T<2 | S<19 | S>43))  || any(is_w & is_r & (T>45 | S<5 | S>45)) )
-	  #   warning("S and/or T is outside the range of validity of the formulation chosen for K1.")
+
+	  if (any(is_w & is_d & (T>45 | T<0 | S>40 | S<20 | b!=0.04))) 
+	    {warning("S, T, and/or b is outside the range of validity for the TRIS buffer pH formulation by DelValls and Dickson (1998).")}
     
-	  if (any(is_w & (T>318.15 | S>40))) 
-	    warning("S and/or T is outside the range of validity of the formulations available for TRIS buffer pH in seacarb.")
+	  if (any(is_w & (T>45 | T<5 | S>40 | b>0.04 | b<0.01))) 
+	    {warning("S, T, and/or b is outside the range of validity for the TRIS buffer pH formulation by Mueller et al. (2018).")}
 	  
 	  attr(tris,"unit") <- "mol/kg"
 	  return(tris)

--- a/R/tris.R
+++ b/R/tris.R
@@ -26,6 +26,7 @@ function(S=35, T=25, b=0.04, k="m18", warn="y")
   #-------Initialise output vector------- 
   
   tris <- rep(NA, n)
+  method <- rep(NA, n)
   
   #-------Change temperature scale from [deg C] to [K] ----
   
@@ -33,10 +34,8 @@ function(S=35, T=25, b=0.04, k="m18", warn="y")
   
   #-------Calculate tris buffer pH based on input values-------
   
-  for(i in (1:n))
-    {  
-    #--------------------------------------------------------------
-    #-------tris characterization by DelValls and Dickson 1998----
+  #--------------------------------------------------------------
+  #-------tris characterization by DelValls and Dickson 1998----
     #
     #       doi: 10.1016/S0967-0637(98)00019-3
     #     
@@ -47,87 +46,83 @@ function(S=35, T=25, b=0.04, k="m18", warn="y")
     #       correct for T range : 0 - 45 °C
     #       correct for S range : 20 - 40
     #       correct for equmolal TRIS/TRISH+ molality b: 0.04 mol/kg-H20
-    #--------------------------------------------------------------  
-    
-    
-	  delvalls1998 = ((11911.08-18.2499*S-0.039336*S^2)*1/(TK))-
-	    366.27059+0.53993607*S+0.00016329*S^2+
-	    ((64.52243-0.084041*S)*log(TK))-
-	    (0.11149858*(TK))
+  #--------------------------------------------------------------  
+  
+  tris_d98 <- ((11911.08-18.2499*S-0.039336*S^2)*1/(TK))-
+	  366.27059+0.53993607*S+0.00016329*S^2+
+	  ((64.52243-0.084041*S)*log(TK))-
+	  (0.11149858*(TK))
+  
+	#--------------------------------------------------------------
+	#-------tris characterization by Mueller et al 2018-----------
+	#
+	#       doi: 10.3389/fmars.2018.00176    
+	#     
+	#       pH of TRIS buffered artifical seawater solutions
+	#       extend to low salinities and different TRIS/TRISH+ molalities
+	#
+	#       pH-scale: total scale
+	#        
+	#       correct for T range : 5 - 45 °C
+	#       correct for S range : 5 - 40
+	#       correct for equmolal TRIS/TRISH+ molalities b: 0.01 - 0.04 mol/kg-H20 for S in 5-20
+	#       correct for equmolal TRIS/TRISH+ molalities b: 0.04 mol/kg-H20 for S in 20-40
+	#--------------------------------------------------------------
 	
-
-	  #--------------------------------------------------------------
-	  #-------tris characterization by Mueller et al 2018-----------
-	  #
-	  #       doi: 10.3389/fmars.2018.00176    
-	  #     
-	  #       pH of TRIS buffered artifical seawater solutions
-	  #       extend to low salinities and different TRIS/TRISH+ molalities
-	  #
-	  #       pH-scale: total scale
-	  #        
-	  #       correct for T range : 5 - 45 °C
-	  #       correct for S range : 5 - 40
-	  #       correct for equmolal TRIS/TRISH+ molalities b: 0.01 - 0.04 mol/kg-H20 for S in 5-20
-	  #       correct for equmolal TRIS/TRISH+ molalities b: 0.04 mol/kg-H20 for S in 20-40
-	  #--------------------------------------------------------------
-
-	  mueller2018 =
-	    -327.3307 -                 
-	    2.400270 * S +    
-	    8.124630e-2 * S^2 -   
-	    9.635344e-4 * S^3 -   
-	    
-	    9.103207e-2 * TK -
-	    1.963311e-3 * S * TK +
-	    6.430229e-5 * S^2 * TK -
-	    7.510992e-7 * S^3 * TK +
-	    
-	    56.92797 * log(TK) +
-	    5.235889e-1 * S * log(TK) -
-	    1.7602e-2 * S^2 * log(TK) +
-	    2.082387e-4 * S^3 * log(TK) +
-	    
-	    11382.97 * (1/TK) -
-	    
-	    2.417045 * b +
-	    7.645221e-2 * b * S +
-	    1.122392e-2 * b * TK -
-	    3.248381e-4 * b * S * TK -
-	    
-	    4.161537 * b^2 +
-	    6.143395e-2 * b^2 * S
-	
-	  #-------------------------------------------------------------------
-	  #-------Choose between tris characterizations (=method)----------
-	
-	  is_d <- (k=='d98')    # everything that is not "k" is "d" by default
-	  tris <- mueller2018
-	  tris[is_d] <- delvalls1998[is_d]
-	
-	  #-------Assign method -------------------
-	
-	  method <- rep(NA, n)
-	  method[!is_d] <- "Mueller et al. (2018)"
-	  method[is_d] <- "DelValls and Dickson (1998)"
+  tris_m18 <-
+	  -327.3307 -                 
+	  2.400270 * S +    
+	  8.124630e-2 * S^2 -   
+	  9.635344e-4 * S^3 -   
 	  
-
-	  #-------Set warnings-----------
-	
-	  is_w <- warn == "y"
-
-	  if (any(is_w & is_d & (T>45 | T<0 | S>40 | S<20 | b!=0.04))) 
-	    {warning("S, T, and/or b is outside the range of validity for the TRIS buffer pH formulation by DelValls and Dickson (1998).")}
-    
-	  if (any(is_w & (T>45 | T<5 | S>40 | b>0.04 | b<0.01))) 
-	    {warning("S, T, and/or b is outside the range of validity for the TRIS buffer pH formulation by Mueller et al. (2018).")}
+	  9.103207e-2 * TK -
+	  1.963311e-3 * S * TK +
+	  6.430229e-5 * S^2 * TK -
+	  7.510992e-7 * S^3 * TK +
 	  
-	  #-------Assign attributes and define return value-----------
+	  56.92797 * log(TK) +
+	  5.235889e-1 * S * log(TK) -
+	  1.7602e-2 * S^2 * log(TK) +
+	  2.082387e-4 * S^3 * log(TK) +
 	  
-	  attr(tris, "method") = method
-	  attr(tris, "pH scale") = "total scale"
-	  attr(tris,"unit") <- "mol/kg-soln"
-	  return(tris)
+	  11382.97 * (1/TK) -
+	  
+	  2.417045 * b +
+	  7.645221e-2 * b * S +
+	  1.122392e-2 * b * TK -
+	  3.248381e-4 * b * S * TK -
+	  
+	  4.161537 * b^2 +
+	  6.143395e-2 * b^2 * S
 	
-    }
-  }
+  #-------------------------------------------------------------------
+	#-------Choose between tris characterizations (=method)----------
+	
+  is_d98 <- (k=='d98')
+  is_m18 <- (k=='m18')
+	
+  tris[is_d98] <- tris_d98[is_d98]
+  tris[is_m18] <- tris_m18[is_m18]
+	
+	#-------Assign method -------------------
+	
+	method[is_d98] <- "DelValls and Dickson (1998)"
+  method[is_m18] <- "Mueller et al. (2018)"
+	
+	#-------Set warnings-----------
+	is_w <- warn == "y"
+	if (any(is_w & is_d98 & (T>45 | T<0 | S>40 | S<20 | b!=0.04))) 
+	  {warning("S, T, and/or b is outside the range of validity for the TRIS buffer pH formulation by DelValls and Dickson (1998).")}
+
+	if (any(is_w & is_m18 & (T>45 | T<5 | S>40 | b>0.04 | b<0.01))) 
+	  {warning("S, T, and/or b is outside the range of validity for the TRIS buffer pH formulation by Mueller et al. (2018).")}
+	
+	#-------Assign attributes and define return value-----------
+	
+	attr(tris, "method") = method
+	attr(tris, "pH scale") = "total scale"
+	attr(tris,"unit") <- "mol/kg-soln"
+	return(tris)
+
+}
+

--- a/R/tris.R
+++ b/R/tris.R
@@ -11,10 +11,12 @@
 #
 
 "tris" <-
-  
-function(S=35, T=25, k="m18", b=0.04)
+function(S=35, T=25, k="m18", b=0.04, warn="y")
   
   {
+  
+  
+  #-------Harmonize input vectors to identical length-------
   
   n <- max(length(S), length(T), length(k), length(b))
   
@@ -24,50 +26,97 @@ function(S=35, T=25, k="m18", b=0.04)
   if(length(b)!=n){b <- rep(b[1],n)}
 
   
-  # Initialise output vector  
+  #-------Initialise output vector------- 
+  
   tris <- rep(NA, n)
+  
+  
+  #---- changing temperature scale from Celsius to Kelvin ----
+  
+  tk = 273.15;           # [K] (for conversion [deg C] <-> [K])
+  TK = T + tk;           # T [C]; TK [K]
+  
+  
+  
+  #-------calculate tris buffer pH based on input-------
   
   
   for(i in (1:n)){  
   
-	delvalls1998 = ((11911.08-18.2499*S[i]-0.039336*S[i]^2)*1/(T[i]+273.15))-
-	  366.27059+0.53993607*S[i]+0.00016329*S[i]^2+
-	  ((64.52243-0.084041*S[i])*log(T[i]+273.15))-
-	  (0.11149858*(T[i]+273.15))
+    
+    #--------------------------------------------------------------
+    #------------------ Ks ----------------------------------------
+    #       Khoo et al. 1977
+    #     
+    #       Equilibrium constant for HSO4- = H+ + SO4--
+    #
+    #       K_S  = [H+]free [SO4--] / [HSO4-]
+    #       pH-scale: free scale !!!
+    #        
+    #      correct for T range : 5 - 40°C
+    #      correct for S range : 20 - 45  
+    
+    
+    
+	delvalls1998 = ((11911.08-18.2499*S-0.039336*S^2)*1/(TK))-
+	  366.27059+0.53993607*S+0.00016329*S^2+
+	  ((64.52243-0.084041*S)*log(TK))-
+	  (0.11149858*(TK))
+	
+
+	#   stop ("TRIS/TRISH+ molality out of range: ", b)
 	
 	mueller2018 =
 	  -327.3307 -
-	    2.400270 * S[i] +
-	    8.124630e-2 * S[i]^2 -
-	    9.635344e-4 * S[i]^3 -
+	    2.400270 * S +
+	    8.124630e-2 * S^2 -
+	    9.635344e-4 * S^3 -
 	    
-	    9.103207e-2 * T[i] -
-	    1.963311e-3 * S[i] * T[i] +
-	    6.430229e-5 * S[i]^2 * T[i] -
-	    7.510992e-7 * S[i]^3 * T[i] +
+	    9.103207e-2 * TK -
+	    1.963311e-3 * S * TK +
+	    6.430229e-5 * S^2 * TK -
+	    7.510992e-7 * S^3 * TK +
 	    
-	    56.92797 * log(T[i]) +
-	    5.235889e-1 * S[i] * log(T[i]) -
-	    1.7602e-2 * S[i]^2 * log(T[i]) +
-	    2.082387e-4 * S[i]^3 * log(T[i]) +
+	    56.92797 * log(TK) +
+	    5.235889e-1 * S * log(TK) -
+	    1.7602e-2 * S^2 * log(TK) +
+	    2.082387e-4 * S^3 * log(TK) +
 	    
-	    11382.97 * (1/T[i]) -
+	    11382.97 * (1/TK) -
 	    
-	    2.417045 * b[i] +
-	    7.645221e-2 * b[i] * S[i] +
-	    1.122392e-2 * b[i] * T[i] -
-	    3.248381e-4 * b[i] * S[i] * T[i] -
+	    2.417045 * b +
+	    7.645221e-2 * b * S +
+	    1.122392e-2 * b * TK -
+	    3.248381e-4 * b * S * TK -
 	    
-	    4.161537 * b[i]^2 +
-	    6.143395e-2 * b[i]^2 * S[i]
+	    4.161537 * b^2 +
+	    6.143395e-2 * b^2 * S
 	
 	
 
-	# flag 1 : seawater to total
-	if (k[i]=="d98") {tris[i] <- delvalls1998[i]} 
-	if (k[i]=="m18") {tris[i] <- mueller2018[i]} 
+	#-------------------------------------------------------------------
+	#--------------- choice between the formulations -------------------
+	is_d <- (k=='d98')    # everything that is not "k" is "d" by default
+	tris <- mueller2018
+	tris[is_d] <- delvalls1998[is_d]
+	
+	method <- rep(NA, nK)
+	method[!is_d] <- "Mueller et al. (2018)"
+	method[is_d] <- "DelValls and Dickson (1998)"
 	
 	
+	
+		
+	
+	##------------Warnings
+	
+	is_w <- warn == "y"
+	
+	# if (any(is_w & (T>35 | T<2 | S<19 | S>43))  || any(is_w & is_r & (T>45 | S<5 | S>45)) )
+	#   warning("S and/or T is outside the range of validity of the formulation chosen for K1.")
+
+	if (any(is_w & (T>318.15 | S>40))) 
+	  warning("S and/or T is outside the range of validity of the formulations available for TRIS buffer pH in seacarb.")
 	
 	attr(tris,"unit") <- "mol/kg"
 	return(tris)

--- a/R/tris.R
+++ b/R/tris.R
@@ -1,5 +1,5 @@
 # Copyright (C) 2009 Jean-Pierre Gattuso
-# Copyright (C) 2018 updated by Jens Daniel Mueller
+# Copyright (C) 2018 Jens Daniel Mueller, update
 #
 # This file is part of seacarb.
 #
@@ -11,7 +11,7 @@
 
 
 "tris" <-
-function(S=35, T=25, k="m18", b=0.04, warn="y")
+function(S=35, T=25, b=0.04, k="m18", warn="y")
   {
   #-------Harmonize input vector length-----
   
@@ -19,8 +19,9 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
   
   if(length(S)!=n){S <- rep(S[1],n)}
   if(length(T)!=n){T <- rep(T[1],n)}
-  if(length(k)!=n){k <- rep(k[1],n)}
   if(length(b)!=n){b <- rep(b[1],n)}
+  if(length(k)!=n){k <- rep(k[1],n)}
+
 
   #-------Initialise output vector------- 
   
@@ -45,7 +46,7 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
     #        
     #       correct for T range : 0 - 45 °C
     #       correct for S range : 20 - 40
-    #       correct for equmolal TRIS/TRISH+ molality b: 0.04 mol/kg
+    #       correct for equmolal TRIS/TRISH+ molality b: 0.04 mol/kg-H20
     #--------------------------------------------------------------  
     
     
@@ -54,7 +55,7 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
 	    ((64.52243-0.084041*S)*log(TK))-
 	    (0.11149858*(TK))
 	
-	
+
 	  #--------------------------------------------------------------
 	  #-------tris characterization by Mueller et al 2018-----------
 	  #
@@ -67,15 +68,15 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
 	  #        
 	  #       correct for T range : 5 - 45 °C
 	  #       correct for S range : 5 - 40
-	  #       correct for equmolal TRIS/TRISH+ molalities b: 0.01 - 0.04 mol/kg for S in 5-20
-	  #       correct for equmolal TRIS/TRISH+ molalities b: 0.04 mol/kg for S in 20-40
+	  #       correct for equmolal TRIS/TRISH+ molalities b: 0.01 - 0.04 mol/kg-H20 for S in 5-20
+	  #       correct for equmolal TRIS/TRISH+ molalities b: 0.04 mol/kg-H20 for S in 20-40
 	  #--------------------------------------------------------------
 
 	  mueller2018 =
-	    -327.3307 -
-	    2.400270 * S +
-	    8.124630e-2 * S^2 -
-	    9.635344e-4 * S^3 -
+	    -327.3307 -                 
+	    2.400270 * S +    
+	    8.124630e-2 * S^2 -   
+	    9.635344e-4 * S^3 -   
 	    
 	    9.103207e-2 * TK -
 	    1.963311e-3 * S * TK +
@@ -97,8 +98,6 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
 	    4.161537 * b^2 +
 	    6.143395e-2 * b^2 * S
 	
-	
-
 	  #-------------------------------------------------------------------
 	  #-------Choose between tris characterizations (=method)----------
 	
@@ -111,7 +110,8 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
 	  method <- rep(NA, n)
 	  method[!is_d] <- "Mueller et al. (2018)"
 	  method[is_d] <- "DelValls and Dickson (1998)"
-	
+	  
+
 	  #-------Set warnings-----------
 	
 	  is_w <- warn == "y"
@@ -122,7 +122,11 @@ function(S=35, T=25, k="m18", b=0.04, warn="y")
 	  if (any(is_w & (T>45 | T<5 | S>40 | b>0.04 | b<0.01))) 
 	    {warning("S, T, and/or b is outside the range of validity for the TRIS buffer pH formulation by Mueller et al. (2018).")}
 	  
-	  attr(tris,"unit") <- "mol/kg"
+	  #-------Assign attributes and define return value-----------
+	  
+	  attr(tris, "method") = method
+	  attr(tris, "pH scale") = "total scale"
+	  attr(tris,"unit") <- "mol/kg-soln"
 	  return(tris)
 	
     }

--- a/R/tris.R
+++ b/R/tris.R
@@ -1,4 +1,4 @@
-# Copyright (C) 2009 Jean-Pierre Gattuso
+# Copyright (C) 2009 Jean-Pierre Gattuso, 2018 updated by Jens Daniel Mueller
 #
 # This file is part of seacarb.
 #
@@ -9,9 +9,70 @@
 # You should have received a copy of the GNU General Public License along with seacarb; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
 #
-"tris" <- 
-function(S=35,T=25){
-	tris = ((11911.08-18.2499*S-0.039336*S^2)*1/(T+273.15))-366.27059+0.53993607*S+0.00016329*S^2+((64.52243-0.084041*S)*log(T+273.15))-(0.11149858*(T+273.15))
+
+"tris" <-
+  
+function(S=35, T=25, k="m18", b=0.04)
+  
+  {
+  
+  n <- max(length(S), length(T), length(k), length(b))
+  
+  if(length(S)!=n){S <- rep(S[1],n)}
+  if(length(T)!=n){T <- rep(T[1],n)}
+  if(length(k)!=n){k <- rep(k[1],n)}
+  if(length(b)!=n){b <- rep(b[1],n)}
+
+  
+  # Initialise output vector  
+  tris <- rep(NA, n)
+  
+  
+  for(i in (1:n)){  
+  
+	delvalls1998 = ((11911.08-18.2499*S[i]-0.039336*S[i]^2)*1/(T[i]+273.15))-
+	  366.27059+0.53993607*S[i]+0.00016329*S[i]^2+
+	  ((64.52243-0.084041*S[i])*log(T[i]+273.15))-
+	  (0.11149858*(T[i]+273.15))
+	
+	mueller2018 =
+	  -327.3307 -
+	    2.400270 * S[i] +
+	    8.124630e-2 * S[i]^2 -
+	    9.635344e-4 * S[i]^3 -
+	    
+	    9.103207e-2 * T[i] -
+	    1.963311e-3 * S[i] * T[i] +
+	    6.430229e-5 * S[i]^2 * T[i] -
+	    7.510992e-7 * S[i]^3 * T[i] +
+	    
+	    56.92797 * log(T[i]) +
+	    5.235889e-1 * S[i] * log(T[i]) -
+	    1.7602e-2 * S[i]^2 * log(T[i]) +
+	    2.082387e-4 * S[i]^3 * log(T[i]) +
+	    
+	    11382.97 * (1/T[i]) -
+	    
+	    2.417045 * b[i] +
+	    7.645221e-2 * b[i] * S[i] +
+	    1.122392e-2 * b[i] * T[i] -
+	    3.248381e-4 * b[i] * S[i] * T[i] -
+	    
+	    4.161537 * b[i]^2 +
+	    6.143395e-2 * b[i]^2 * S[i]
+	
+	
+
+	# flag 1 : seawater to total
+	if (k[i]=="d98") {tris[i] <- delvalls1998[i]} 
+	if (k[i]=="m18") {tris[i] <- mueller2018[i]} 
+	
+	
+	
 	attr(tris,"unit") <- "mol/kg"
 	return(tris)
+	
+  }
+	
+	
 }

--- a/man/pHspec.Rd
+++ b/man/pHspec.Rd
@@ -1,0 +1,53 @@
+\encoding{latin1}
+\name{pHspec}
+\alias{pHspec}
+
+\title{Calculates pHT from results of spectrophotometric measurements}
+\description{Calculates pH of a water sample from absorbance ratios R, obtained from spectrophotometric measurements with pH indicator dyes (on the total scale in mol/kg-soln)}
+\usage{
+pHspec(S=35, T=25, R=1, d="mCP", k="m18", warn="y")
+%- maybe also 'usage' for other objects documented here.
+}
+
+\arguments{
+  \item{S}{Salinity, default is 35}
+  \item{T}{Temperature in degrees Celsius, default is 25oC}
+  \item{R}{Absorbance ratio, default is 1}
+  \item{d}{Dye used for spectrophotometric measurement, default is "mCP"}
+  \item{k}{"m18" for using mCP characterization by Mueller and Rehder (2018)} 
+  \item{warn}{"y" to show warnings when S and/or T go beyond the valid range for the chosen d and k; "n" to supress warnings. The default is "y".}
+}
+
+\details{The model used to calculate the return value of this function is based on experimental data. It is critical to consider that the formulation refers to the conditions studied during the characterization experiment and is only valid for the studied ranges of temperature and salinity:
+\itemize{
+\item Mueller and Rehder (2018): S ranging between 0 and 40, T ranging between 5 and 35oC, and the dye used being m-Cresol purple (mCP) with R referring to the ratio of absorbances at wavelengths 578 and 434 nm.
+
+}
+Note that the arguments can be given as a unique number or as vectors. If the lengths of the vectors are different, the longer vector is retained and only the first value of the other vectors is used. It can therefore be critical to use vectors of the same length.
+} 
+
+\value{
+  \item{pHspec}{The function returns the pH value of a water sample from absorbance ratios R, obtained from spectrophotometric measurements with pH indicator dyes (on the total scale in mol/kg-soln)}
+
+}
+\references{
+Mueller, J. D. and Rehder, G., 2018 Metrology for pH Measurements in Brackish Waters - Part 2: Experimental Characterization of Purified meta-Cresol Purple for Spectrophotometric pHT Measurements. \emph{Frontiers in Marine Science} \bold{5:177}, 1-9. https://doi.org/10.3389/fmars.2018.00177
+
+
+}
+
+\author{
+Jens Daniel Mueller \email{jens.mueller@io-warnemuende.de}
+
+Jean-Pierre Gattuso \email{gattuso@obs-vlfr.fr}
+}
+
+\seealso{
+	\code{\link{amp}}, \code{\link{pHslope}}, \code{\link{pH}}. \code{\link{tris}},
+}
+
+\examples{
+	##Example should give test value pHT = 7.6713
+	 pHspec(S=35, T=25, R=1, d="mCP", k="m18", warn="y")
+}
+\keyword{utilities}

--- a/man/tris.Rd
+++ b/man/tris.Rd
@@ -2,30 +2,43 @@
 \name{tris}
 \alias{tris}
 
-\title{pH value of the TRIS buffer}
-\description{pH value of the TRIS buffer (on the total scale in mol/kg)}
+\title{pH of TRIS buffer}
+\description{Calculates the pH value of TRIS buffered artificial seawater solutions (on the total scale in mol/kg-soln)}
 \usage{
-tris(S=35,T=25)
+tris(S=35,T=25,b=0.04,k="m18",warn="y")
 %- maybe also 'usage' for other objects documented here.
 }
 
 \arguments{
   \item{S}{Salinity, default is 35}
   \item{T}{Temperature in degrees Celsius, default is 25oC}
+  \item{b}{Molality if TRIS/TRISH+ in moles per kg of water, default is 0.04 mol/kg-H20}
+  \item{k}{"m18" for using tris characterization by Mueller et al (2018), "d98" for DelValls and Dickson 1998, default is "m18"} 
+  \item{warn}{"y" to show warnings when S,T and/or b go beyond the valid range for the chosen k; "n" to supress warnings. The default is "y".}
 }
 
-\details{Note that the arguments can be given as a unique number or as vectors. If the lengths of the vectors are different, the longer vector is retained and only the first value of the other vectors is used. It can therefore be critical to use vectors of the same length.} 
+\details{The models used to calculate the return value of this function are based on experimental data. It is critical to consider that each formulation refers to the artificial seawater solution applied during the characterization experiment and is only valid for the studied ranges of temperature and salinity:
+\itemize{
+\item Mueller et al. (2018): S ranging between 5 and 40, T ranging between 5 and 45oC, and b ranging between 0.01 and 0.04 mol/kg-H20.
+\item DelValls and Dickson (1998): S ranging between 20 and 40, T ranging between 0 and 45oC, and b being 0.04 mol/kg-H20.
+}
+Note that the arguments can be given as a unique number or as vectors. If the lengths of the vectors are different, the longer vector is retained and only the first value of the other vectors is used. It can therefore be critical to use vectors of the same length.
+} 
 
 \value{
-  \item{tris}{pH value of the TRIS buffer (on the total scale in mol/kg)}
+  \item{tris}{The function returns the pH value of TRIS buffered artificial seawater solutions (on the total scale in mol/kg-soln)}
 
 }
 \references{
+Mueller, J. D., Bastkowski, F., Sander, B., Seitz, S., Turner, D. R., Dickson, A. G., and Rehder, G., 2018 Metrology for pH Measurements in Brackish Waters—Part 1: Extending Electrochemical pHT Measurements of TRIS Buffers to Salinities 5–20. \emph{Frontiers in Marine Science} \bold{5:176}, 1–12. https://doi.org/10.3389/fmars.2018.00176
+
+DelValls, T. A., and Dickson, A. G., 1998 The pH of buffers based on 2-amino-2-hydroxymethyl-1,3-propanediol (‘tris’) in synthetic sea water. \emph{Deep Sea Research Part I: Oceanographic Research Papers} \bold{45(9)}, 1541–1554. https://doi.org/10.1016/S0967-0637(98)00019-3
+
 Dickson A. G., Sabine C. L. and Christian J. R., 2007 Guide to best practices for ocean CO2 measurements. \emph{PICES Special Publication} \bold{3}, 1-191.
 }
 
 \author{
-Jean-Pierre Gattuso \email{gattuso@obs-vlfr.fr}
+Jens Daniel Mueller \email{jens.mueller@io-warnemuende.de} and Jean-Pierre Gattuso \email{gattuso@obs-vlfr.fr}
 }
 
 \seealso{
@@ -33,7 +46,7 @@ Jean-Pierre Gattuso \email{gattuso@obs-vlfr.fr}
 }
 
 \examples{
-	##Example from Dickson et al. (2007)
-	tris(S=35,T=25)
+	##Example from Mueller et al. (2018), should give test value pHT = 8.0703
+	 tris(S=20,T=25,b=0.04,k="m18")
 }
 \keyword{utilities}


### PR DESCRIPTION
A new function “pHspec.R” to calculate the pHT of water sample from spectrophotometric measurements with the indicator dye m-Cresol purple was implemented and a respective description “pHspec.Rd” was added.

The latest version of the function “tris.R” was used as a template, in order to meet seacarb standards. The function “pHspec” includes options to choose the dye and dye parameterization.

Currently only the formulation for one dye (“mCP”) with one characterization (“m18”) is available, but extensions are anticipated. Please check the code and, if all seems fine, include it into seacarb.