### PR TITLE
New functions to compute H+ activity coefficient and make NBS-SWS conversions

### DIFF
--- a/R/K1.R
+++ b/R/K1.R
@@ -125,7 +125,7 @@ function(S=35,T=25,P=0,k1k2='x',pHscale="T",kSWS2scale="x",ktotal2SWS_P0="x",war
     pK1 <- 3404.71/TK[is_cw] + 0.032786*TK[is_cw] - 14.8435 - 0.071692*F1*S[is_cw]^0.5 + 0.0021487*S[is_cw] #*F1
     K1[is_cw]  <- 10^(-pK1)         # this is on the NBS scale
     # Convert from NBS to SWS scale using combined activity coefficient fH 
-    # Takahashi (1982, GEOSECS Pacific Expedition, Chap 3, p. 80), who says:
+    # Takahashi (1982, GEOSECS Pacific Expedition, Chap 3, p. 80), who say:
     # "fH is the total activity coeff., which includes contributions from HSO4- and HF [as well as H+].
     #  Culberson and Pytkowicz (28) determined fH as a function of temperature and salinity, and
     #  their results can be approximated by:"

--- a/R/K2.R
+++ b/R/K2.R
@@ -145,7 +145,7 @@ function(S=35,T=25,P=0,k1k2='x',pHscale="T",kSWS2scale="x",ktotal2SWS_P0="x",war
     pK2[is_cw] <- 2902.39/TK[is_cw] - 6.4980 - 0.3191*F2*S[is_cw]^0.5 + 0.0198*S[is_cw]
     K2[is_cw] <- 10.0^(-pK2)         # this is on the NBS scale
     # Convert from NBS to SWS scale using combined activity coefficient fH 
-    # Takahashi (1982, GEOSECS Pacific Expedition, Chap 3, p. 80), who says:
+    # Takahashi (1982, GEOSECS Pacific Expedition, Chap 3, p. 80), who say:
     # "fH is the total activity coeff., which includes contributions from HSO4- and HF [as well as H+].
     #  Culberson and Pytkowicz (28) determined fH as a function of temperature and salinity, and
     #  their results can be approximated by:"

--- a/R/fH.R
+++ b/R/fH.R
@@ -26,7 +26,11 @@ fH <- function(S=35, T=25){
     #  Culberson & Pytkowicz (28) determined fH as a function of temperature and salinity, and
     #  their results can be approximated by:"
 
-    f = (1.2948 - 0.002036*T + (0.0004607 - 0.000001475*T)*S^2)
+    tk <- 273.15;           # [K] (for conversion [deg C] <-> [K])
+    TK <- T + tk;           # T [C]; T [K]
+ 
+    #f = (1.2948 - 0.002036*TK + (0.0004607 - 0.000001475*TK)*S^2)       #CO2SYS.m code
+    f  =  1.2948 - 0.002036*TK + 4.607e-4 * S^2  - 1.475e-6 * S^2 * TK   #eqn just as in Takahashi et al.
 
     # The approach used to compute fH is old. Its use to convert between the NBS and SWS scales is
     # full of uncertainty.  Newer approaches are more complicated (Pitzer equations) but big uncertainties

--- a/R/fH.R
+++ b/R/fH.R
@@ -1,0 +1,44 @@
+# Copyright (C) 2024 James Orr
+# This file is part of seacarb.
+# Seacarb is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or any later version.
+# Seacarb is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with seacarb; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Compute total hydrogen ion activity coefficient to convert between SWS and NBS scales
+
+fH <- function(S=35, T=25){
+    # --------------------------------------------------------------------------------------------------------------
+    # ah = fH * [H+]sws
+    # where ah  is the activity of hydrogen ion,
+    #       fH  is the total activity coefficient, and
+    #       [H+]sws = [H+] + [HSO4-] + [HF], or in other words "the hydrogen ion conccentration on the seawater scale"
+    #
+    # Note:
+    # -----
+    # pHnbs = -log10(ah)       #pH on the NBS scale
+    # phsws = -log10([H+]sws)  #pH on the SWS scale
+    # --------------------------------------------------------------------------------------------------------------
+
+    # The activity coefficient (fH) is used to convert from H+ conccentration on SWS scale 
+    # to H+ activity (ah), as used for NBS scale and vice versa. 
+    # Here, fH is taken from Takahashi et al (1982, GEOSECS Pacific Expedition, Chap 3, p. 80) who say:
+    # "fH is the total activity coeff., which includes contributions from HSO4- and HF [as well as H+].
+    #  Culberson & Pytkowicz (28) determined fH as a function of temperature and salinity, and
+    #  their results can be approximated by:"
+
+    f = (1.2948 - 0.002036*T + (0.0004607 - 0.000001475*T)*S^2)
+
+    # The approach used to compute fH is old. Its use to convert between the NBS and SWS scales is
+    # full of uncertainty.  Newer approaches are more complicated (Pitzer equations) but big uncertainties
+    # remain (Marion et al., 2011; Pilson, 2013).
+    #
+    # Culberson, CH, & Pytkowicz, RM (1973). Ionization of water in seawater. Marine Chemistry, 1(4), 309-316.
+    #
+    # Marion GM, Millero FJ, Camoes MF, Spitzer P, Feistel R, Chen CTA. 2011. pH of seawater. Marine Chemistry 126: 89-96
+    #
+    # Pilson MEQ. 2013. An introduction to the chemistry of the sea, 2 edn. Cambridge, UK: Cambridge University Press.
+    #
+    # Takahashi, T. et al (1982). Carbonate chemistry. GEOSECS Pacific Expedition, Volume 3, Hydrographic Data 1973-1974, 77-83.
+
+return(f)
+}

--- a/R/pHnbs2sws.R
+++ b/R/pHnbs2sws.R
@@ -1,0 +1,39 @@
+# Copyright (C) 2024 James Orr
+# This file is part of seacarb.
+# Seacarb is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or any later version.
+# Seacarb is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with seacarb; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Convert pHNBS to pHSWS using the total hydrogen ion activity coefficient, which depends on T and S
+
+pHnbs2sws <- function(pHNBS, S=35, T=25){
+    # --------------------------------------------------------------------------------------------------------------
+    # pHNBS = -log10(ah)       #pH on the NBS scale  (-log10 of the activity, not the concentration)
+    # phSWS = -log10([H+]sws)  #pH on the SWS scale  (-log10 of the concentration)
+    # 
+    # Note:
+    # -----
+    # ah = fH * [H+]sws
+    # where ah  is the activity of hydrogen ion,
+    #       fH  is the total activity coefficient, and
+    #       [H+]sws = [H+] + [HSO4-] + [HF], or in other words "the hydrogen ion conccentration on the seawater scale"
+    # --------------------------------------------------------------------------------------------------------------
+    #
+    # The NBS-to-SWS conversion is done with the total activity coefficient fH (combined activity coeff for H+, HSO4-, and HF)
+    # from Takahashi (1982) based on data from Culberson and Pytkowicz (1973). The approach is old and full of uncertainty.
+    # Newer approaches are more complicated (Pitzer equations) and big uncertainties remain (Marion et al., 2011; Pilson, 2013).
+    #
+    # Culberson, CH, & Pytkowicz, RM (1973). Ionization of water in seawater. Marine Chemistry, 1(4), 309-316.
+    #
+    # Marion GM, Millero FJ, Camoes MF, Spitzer P, Feistel R, Chen CTA. 2011. pH of seawater. Marine Chemistry 126: 89-96
+    #
+    # Pilson MEQ. 2013. An introduction to the chemistry of the sea, 2 edn. Cambridge, UK: Cambridge University Press.
+    #
+    # Takahashi, T. et al (1982). Carbonate chemistry. GEOSECS Pacific Expedition, Volume 3, Hydrographic Data 1973-1974, 77-83.
+
+    ah    <-  10^(-pHNBS)      
+    hSWS  <-  ah / fH(S=S, T=T)
+    pHSWS <- -log10(hSWS) 
+
+return(pHSWS)
+}

--- a/R/pHsws2nbs.R
+++ b/R/pHsws2nbs.R
@@ -1,0 +1,39 @@
+# Copyright (C) 2024 James Orr
+# This file is part of seacarb.
+# Seacarb is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or any later version.
+# Seacarb is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with seacarb; if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+# Convert pHSWS to pHNBS using the total hydrogen ion activity coefficient, which depends on T and S
+
+pHsws2nbs <- function(pHSWS, S=35, T=25){
+    # --------------------------------------------------------------------------------------------------------------
+    # phSWS = -log10([H+]sws)  #pH on the SWS scale  (-log10 of the concentration)
+    # pHNBS = -log10(ah)       #pH on the NBS scale  (-log10 of the activity, not the concentration)
+    # 
+    # Note:
+    # -----
+    # ah = fH * [H+]sws
+    # where ah  is the activity of hydrogen ion,
+    #       fH  is the total activity coefficient, and
+    #       [H+]sws = [H+] + [HSO4-] + [HF], or in other words "the hydrogen ion conccentration on the seawater scale"
+    # --------------------------------------------------------------------------------------------------------------
+    #
+    # The SWS-to-NBS conversion is done with the total activity coefficient fH (combined activity coeff for H+, HSO4-, and HF)
+    # from Takahashi (1982) based on data from Culberson and Pytkowicz (1973). The approach is old and full of uncertainty.
+    # Newer approaches are more complicated (Pitzer equations) and big uncertainties remain (Marion et al., 2011; Pilson, 2013).
+    #
+    # Culberson, CH, & Pytkowicz, RM (1973). Ionization of water in seawater. Marine Chemistry, 1(4), 309-316.
+    #
+    # Marion GM, Millero FJ, Camoes MF, Spitzer P, Feistel R, Chen CTA. 2011. pH of seawater. Marine Chemistry 126: 89-96
+    #
+    # Pilson MEQ. 2013. An introduction to the chemistry of the sea, 2 edn. Cambridge, UK: Cambridge University Press.
+    #
+    # Takahashi, T. et al (1982). Carbonate chemistry. GEOSECS Pacific Expedition, Volume 3, Hydrographic Data 1973-1974, 77-83.
+
+    hSWS  <- 10^(-pHSWS)
+    ah    <-  fH(S=S, T=T) * hSWS
+    pHNBS <- -log10(ah)
+
+return(pHNBS)
+}

--- a/man/carb.Rd
+++ b/man/carb.Rd
@@ -200,11 +200,11 @@ Heloise Lavigne, James Orr and Jean-Pierre Gattuso \email{jean-pierre.gattuso@im
 
 \examples{
 
-## With a couple of variables
+## 1. With a couple of variables
 carb(flag=8, var1=8.2, var2=0.00234, S=35, T=25, P=0, Patm=1.0, Pt=0, Sit=0,
 	pHscale="T", kf="pf", k1k2="l", ks="d", b="u74")
 
-## Using vectors as arguments
+## 2. Using vectors as arguments
 flag <- c(8, 2, 8)
 var1 <- c(8.2, 7.477544e-06, 8.2)
 var2 <- c(0.002343955, 0.001649802, 2400e-6)
@@ -218,9 +218,35 @@ k1k2 <- c("l", "l", "l")
 pHscale <- c("T", "T", "T")
 b <- c("l10", "l10", "l10")
 carb(flag=flag, var1=var1, var2=var2, S=S, T=T, P=P,
-  Pt=Pt, Sit=Sit, kf=kf, k1k2=k1k2, pHscale=pHscale, b=b)
+	Pt=Pt, Sit=Sit, kf=kf, k1k2=k1k2, pHscale=pHscale, b=b)
 
-## Test with all flags 
+## 3. Special case: when pH for input is on NBS scale (not a standard option in seacarb) 
+##    -> example for pH-Alk input pair (flag 8) and Cai & Wang (1998) K1,K2 
+pHNBS <- c(8.2, 8.1, 8.0)
+talk <- c(2300, 2350, 2400) * 1e-6
+S <- c(35, 32.5, 30)
+T <- c(25, 15, 10)
+
+## 3a. use seacarb function, fH, which computes the total activity coefficient
+ah    <- 10^(-phNBS)      
+hSWS  <- ah / fH(S=S, T=T)
+phSWS <- -log10(hSWS) 
+carb(flag=8, var1=phSWS, var2=talk, S=S, T=T, P=0, Patm=1.0, Pt=0, Sit=0,
+	pHscale="SWS", kf="pf", k1k2="cw", ks="d", b="u74")
+
+## 3b. same as 3a but fewer lines: use seacarb function, pHnbs2sws, which converts pHNBS to pHSWS (using fH)
+pHSWS <- pHnbs2sws(pHNBS, S=S, T=T)
+carb(flag=8, var1=phSWS, var2=talk, S=S, T=T, P=0, Patm=1.0, Pt=0, Sit=0,
+	pHscale="SWS", kf="pf", k1k2="cw", ks="d", b="u74")
+
+## 3c. conversely for input pairs without pH,  convert computed pH on SWS scale to NBS scale, with function pHsws2nbs
+##    -> example for Alk-DIC input pair (flag 15) and Cai & Wang (1998) K1,K2 
+dic <- c(2000., 2030., 2060) * 1e-6
+output = carb(flag=15, var1=talk, var2=dic, S=S, T=T, P=0, Patm=1.0, Pt=0, Sit=0,
+	pHscale="SWS", kf="pf", k1k2="cw", ks="d", b="u74")
+pHNBS  = pHsws2nbs(output$pH, S=S, T=T)
+
+## 4. Test with all flags 
 flag <- c((1:15), (21:25))
 var1 <- c(8.200000, 7.308171e-06, 7.308171e-06, 7.308171e-06, 7.308171e-06, 
 	8.2, 8.2, 8.2, 8.2, 0.001646857, 0.001646857, 0.001646857, 0.0002822957, 
@@ -231,15 +257,15 @@ var2 <- c(7.308171e-06, 0.001646857, 0.0002822957, 0.00234, 0.001936461,
 	0.001646857, 0.0002822957, 0.00234, 0.001936461)
 carb(flag=flag, var1=var1, var2=var2)
 
-## Test using a data frame 
+## 5. Test using a data frame 
 data(seacarb_test_P0)	#test data set for P=0 (surface)
 tab <- seacarb_test_P0[14:19,]
 
-## method 1 using the column numbers
+## 5a. method 1 using the column numbers
 carb(flag=tab[[1]], var1=tab[[2]], var2=tab[[3]], S=tab[[4]], T=tab[[5]], 
 P=tab[[6]], Sit=tab[[8]], Pt=tab[[7]])
 
-## method 2 using the column names
+## 5b. method 2 using the column names
 carb(flag=tab$flag, var1=tab$var1, var2=tab$var2, S=tab$S, T=tab$T, 
 P=tab$P, Sit=tab$Sit, Pt=tab$Pt)
 

--- a/man/fH.Rd
+++ b/man/fH.Rd
@@ -3,12 +3,14 @@
 \alias{fH}
 \title{Total activity coefficient for H+}
 \description{Compute total hydrogen ion activity coefficient.
-The activity coefficient (fH) is used to convert from H+ conccentration on SWS scale 
-to H+ activity (ah), as used for NBS scale and vice versa. Here, fH is taken from Takahashi 
-et al (1982, GEOSECS Pacific Expedition, Chap 3, p. 80) who say:
-fH is the total activity coeff., which includes contributions from HSO4- and HF [as well as H+].
+The activity coefficient (fH) is used to convert from H+ concentration on SWS scale 
+to H+ activity (ah), as used for NBS scale; likewise fH is used to make the conversion 
+in the opposite direction, from the NBS scale to the SWS scale. Here, fH is taken from 
+Takahashi et al (1982, GEOSECS Pacific Expedition, Chap 3, p. 80) who say:
+fH is the total activity coeff., which includes contributions from HSO4- 
+and HF [as well as H+].
 
-Takahashi et al. (1982) computed a relationship for fH based on experimental data
+Takahashi et al. (1982) computed a relationship for fH based on the experimental data
 from Culberson & Pytkowicz (1973), who determined it experimentally as a function
 of temperature and salinity.  The approach is old and full of uncertainty.
 Newer approaches are more complicated (Pitzer equations) 
@@ -64,7 +66,7 @@ James Orr \email{james.orr@lsce.ipsl.fr}
 ## Compute fH
    f = fH(T=25, S=35)
    print(f)
-## The result is (give check value here)
+## Check value: The result is 0.7134043
 }
 
 \keyword{utilities}

--- a/man/fH.Rd
+++ b/man/fH.Rd
@@ -1,0 +1,70 @@
+\encoding{latin1}
+\name{fH}
+\alias{fH}
+\title{Total activity coefficient for H+}
+\description{Compute total hydrogen ion activity coefficient.
+The activity coefficient (fH) is used to convert from H+ conccentration on SWS scale 
+to H+ activity (ah), as used for NBS scale and vice versa. Here, fH is taken from Takahashi 
+et al (1982, GEOSECS Pacific Expedition, Chap 3, p. 80) who say:
+fH is the total activity coeff., which includes contributions from HSO4- and HF [as well as H+].
+
+Takahashi et al. (1982) computed a relationship for fH based on experimental data
+from Culberson & Pytkowicz (1973), who determined it experimentally as a function
+of temperature and salinity.  The approach is old and full of uncertainty.
+Newer approaches are more complicated (Pitzer equations) 
+and big uncertainties remain (Marion et al., 2011; Pilson, 2013).
+}
+\usage{
+fH(S=35, T=25)
+}
+\arguments{
+  \item{S}{Salinity on the practical salinity scale, default is 35}
+  \item{T}{Temperature in degrees Celsius, default is 25oC}
+  }
+
+\value{
+  \item{fH}{Total activity coefficient for H+}
+}
+
+\details{
+This total activity coefficient appears in
+the following basic chemistry equation: \eqn{ ah = fH * hsws}, 
+where  \eqn{ah}  is the activity of hydrogen ion,
+\eqn{fH}  is the total activity coefficient, and
+\eqn{hsws = [H+] + [HSO4-] + [HF]}. In other words, 
+\eqn{hsws} is the total hydrogen ion conccentration on the seawater scale.
+
+The two pH scales of concern are defined as \eqn{pHNBS = -log10(ah)} and 
+\eqn{pHSWS = -log10(hsws)}.  
+}
+
+\references{
+Culberson, C.H., & Pytkowicz, R.M. (1973). Ionization of water in seawater. 
+\emph{Marine Chemistry}, \bold{1(4)}, 309-316.
+
+Marion G.M., Millero F.J., Camoes M.F., Spitzer P., Feistel R., Chen C.T.A. 2011. pH of seawater. 
+\emph{Marine Chemistry} \bold{126} 89-96.
+
+Pilson M.E.Q. (2013) An introduction to the chemistry of the sea, 
+2 edn. Cambridge, UK: Cambridge University Press.
+
+Takahashi T., Williams R.T., and Ros D.L. (1982) Carbonate chemistry. 
+GEOSECS Pacific Expedition, Volume 3, Hydrographic Data 1973-1974, 77-83.
+}
+             
+\author{
+James Orr \email{james.orr@lsce.ipsl.fr}
+}
+
+\seealso{
+	\code{\link{pHnbs2sws}} and \code{\link{pHsws2nbs}}
+}
+
+\examples{
+## Compute fH
+   f = fH(T=25, S=35)
+   print(f)
+## The result is (give check value here)
+}
+
+\keyword{utilities}

--- a/man/pHnbs2sws.Rd
+++ b/man/pHnbs2sws.Rd
@@ -1,0 +1,66 @@
+\encoding{latin1}
+\name{pHnbs2sws}
+\alias{pHnbs2sws}
+\title{Converts pH from NBS to SWS scale}
+\description{Converts pH on NBS scale to pH on SWS scale pCO2. 
+The NBS-to-SWS conversion is done with the total activity coefficient fH (combined activity coeff for H+, HSO4-, and HF)
+from Takahashi et al. (1982) based on data from Culberson and Pytkowicz (1973). The approach is old and full of uncertainty.
+Newer approaches are more complicated (Pitzer equations) and big uncertainties remain (Marion et al., 2011; Pilson, 2013).
+}
+\usage{
+pHnbs2sws(pHNBS, S=35, T=25)
+}
+\arguments{
+  \item{pHNBS}{pH on NBS scale}
+  \item{S}{Salinity on the practical salinity scale, default is 35}
+  \item{T}{Temperature in degrees Celsius, default is 25oC}
+  }
+
+\value{
+  \item{pHSWS}{pH on SWS scale}
+}
+
+\details{
+The pHSWS is computed from pHNBS using the total activity coefficient and 
+relying on the following basic chemistry equation: \eqn{ ah = fH * hsws}, 
+where  \eqn{ah}  is the activity of hydrogen ion,
+\eqn{fH}  is the total activity coefficient, and
+\eqn{hsws = [H+] + [HSO4-] + [HF]}. In other words, 
+\eqn{hsws} is the total hydrogen ion conccentration on the seawater scale.
+
+The two pH scales are defined as \eqn{pHNBS = -log10(ah)} and 
+\eqn{pHSWS = -log10(hsws)}.  
+}
+
+\references{
+Culberson, C.H., & Pytkowicz, R.M. (1973). Ionization of water in seawater. 
+\emph{Marine Chemistry}, \bold{1(4)}, 309-316.
+
+Marion G.M., Millero F.J., Camoes M.F., Spitzer P., Feistel R., Chen C.T.A. 2011. pH of seawater. 
+\emph{Marine Chemistry} \bold{126} 89-96.
+
+Pilson M.E.Q. (2013) An introduction to the chemistry of the sea, 
+2 edn. Cambridge, UK: Cambridge University Press.
+
+Takahashi T., Williams R.T., and Ros D.L. (1982) Carbonate chemistry. 
+GEOSECS Pacific Expedition, Volume 3, Hydrographic Data 1973-1974, 77-83.
+
+}
+             
+\author{
+James Orr \email{james.orr@lsce.ipsl.fr}
+}
+
+\seealso{
+	\code{\link{fH}} and \code{\link{pHsws2nbs}}
+}
+
+\examples{
+## Convert pHNBS to pHSWS
+   pHNBS = 8.0                          # pH on the NBS scale
+   pHSWS = pHnbs2sws(pHNBS, T=25, S=35) # pH on the SWS scale
+   print(pHSWS)
+## The result is (give check value here)
+}
+
+\keyword{utilities}

--- a/man/pHnbs2sws.Rd
+++ b/man/pHnbs2sws.Rd
@@ -26,7 +26,7 @@ relying on the following basic chemistry equation: \eqn{ ah = fH * hsws},
 where  \eqn{ah}  is the activity of hydrogen ion,
 \eqn{fH}  is the total activity coefficient, and
 \eqn{hsws = [H+] + [HSO4-] + [HF]}. In other words, 
-\eqn{hsws} is the total hydrogen ion conccentration on the seawater scale.
+\eqn{hsws} is the hydrogen ion concentration on the seawater scale.
 
 The two pH scales are defined as \eqn{pHNBS = -log10(ah)} and 
 \eqn{pHSWS = -log10(hsws)}.  
@@ -60,7 +60,7 @@ James Orr \email{james.orr@lsce.ipsl.fr}
    pHNBS = 8.0                          # pH on the NBS scale
    pHSWS = pHnbs2sws(pHNBS, T=25, S=35) # pH on the SWS scale
    print(pHSWS)
-## The result is (give check value here)
+## Check value: the result should be 7.853336
 }
 
 \keyword{utilities}

--- a/man/pHsws2nbs.Rd
+++ b/man/pHsws2nbs.Rd
@@ -26,7 +26,7 @@ relying on the following basic chemistry equation: \eqn{ ah = fH * hsws},
 where  \eqn{ah}  is the activity of hydrogen ion,
 \eqn{fH}  is the total activity coefficient, and
 \eqn{hsws = [H+] + [HSO4-] + [HF]}. In other words, 
-\eqn{hsws} is the total hydrogen ion conccentration on the seawater scale.
+\eqn{hsws} is the hydrogen ion concentration on the seawater scale.
 
 The two pH scales are defined as \eqn{pHNBS = -log10(ah)} and 
 \eqn{pHSWS = -log10(hsws)}.  
@@ -56,10 +56,10 @@ James Orr \email{james.orr@lsce.ipsl.fr}
 
 \examples{
 ## Convert pHSWS to pHNBS
-   pHSWS = 8.0                          # pH on the SWS scale
-   pHNBS = pHnbs2sws(pHNBS, T=25, S=35) # pH on the NBS scale
+   pHSWS = 7.853336                     # pH on the SWS scale
+   pHNBS = pHsws2nbs(pHSWS, T=25, S=35) # pH on the NBS scale
    print(pHNBS)
-## The result is (give check value here)
+## Check value: the result should be 8.0
 }
 
 \keyword{utilities}

--- a/man/pHsws2nbs.Rd
+++ b/man/pHsws2nbs.Rd
@@ -1,0 +1,65 @@
+\encoding{latin1}
+\name{pHsws2nbs}
+\alias{pHsws2nbs}
+\title{Converts pH from SWS to NBS scale}
+\description{Converts pH on SWS scale to pH on NBS scale pCO2. 
+The SWS-to-NBS conversion is done with the total activity coefficient fH (combined activity coeff for H+, HSO4-, and HF)
+from Takahashi et al. (1982) based on data from Culberson and Pytkowicz (1973). The approach is old and full of uncertainty.
+Newer approaches are more complicated (Pitzer equations) and big uncertainties remain (Marion et al., 2011; Pilson, 2013).
+}
+\usage{
+pHsws2nbs(pHSWS, S=35, T=25)
+}
+\arguments{
+  \item{pHSWS}{pH on SWS scale}
+  \item{S}{Salinity on the practical salinity scale, default is 35}
+  \item{T}{Temperature in degrees Celsius, default is 25oC}
+  }
+
+\value{
+  \item{pHNBS}{pH on NBS scale}
+}
+
+\details{
+The pHNBS is computed from pHSWS using the total activity coefficient and 
+relying on the following basic chemistry equation: \eqn{ ah = fH * hsws}, 
+where  \eqn{ah}  is the activity of hydrogen ion,
+\eqn{fH}  is the total activity coefficient, and
+\eqn{hsws = [H+] + [HSO4-] + [HF]}. In other words, 
+\eqn{hsws} is the total hydrogen ion conccentration on the seawater scale.
+
+The two pH scales are defined as \eqn{pHNBS = -log10(ah)} and 
+\eqn{pHSWS = -log10(hsws)}.  
+}
+
+\references{
+Culberson, C.H., & Pytkowicz, R.M. (1973). Ionization of water in seawater. 
+\emph{Marine Chemistry}, \bold{1(4)}, 309-316.
+
+Marion G.M., Millero F.J., Camoes M.F., Spitzer P., Feistel R., Chen C.T.A. 2011. pH of seawater. 
+\emph{Marine Chemistry} \bold{126} 89-96.
+
+Pilson M.E.Q. (2013) An introduction to the chemistry of the sea, 
+2 edn. Cambridge, UK: Cambridge University Press.
+
+Takahashi T., Williams R.T., and Ros D.L. (1982) Carbonate chemistry. 
+GEOSECS Pacific Expedition, Volume 3, Hydrographic Data 1973-1974, 77-83.
+}
+             
+\author{
+James Orr \email{james.orr@lsce.ipsl.fr}
+}
+
+\seealso{
+	\code{\link{fH}} and \code{\link{pHnbs2sws}}
+}
+
+\examples{
+## Convert pHSWS to pHNBS
+   pHSWS = 8.0                          # pH on the SWS scale
+   pHNBS = pHnbs2sws(pHNBS, T=25, S=35) # pH on the NBS scale
+   print(pHNBS)
+## The result is (give check value here)
+}
+
+\keyword{utilities}


### PR DESCRIPTION
I've added 3 new functions to facilitate conversion of pH from the NBS to SWS scale so that Ray Najjar and CHALK project members (and other NBSers) can still use seacarb.  As discussed by phone, this approach avoids any change to the seacarb machinery, such as actually adding the NBS scale as a 4th option. Thus it maintains the seacarb strategy but opens a window for the NBS outsiders to take advantage of seacarb's many nice features.

To see how it would work, take a quick look at the "examples" section of the modified **carb.Rd** file, namely parts 3a, 3b, and 3c.

Here's the list of the 3 new routines:
**fH.R** - computes the the "total" activity coefficient, which is needed to compute H+ activity from [H+]sws
**pHnbs2sws.R** - converts pH from the NBS to SWS scale with fH (used before calling carb with input pairs that include pH)
**pHsws2nbs.R** - converts pH from the SWS to NBS scale with fH (used after calling carb with input pairs that don't include pH)

Also included are corresponding documentation files: fh.Rd, pHnbs2sws.Rd, and pHsws2nbs.Rd

These routines are not final because I would still like to add check values to the .Rd files. Also,I would also want to actually run these routines and examples to rule out bugs.