### PR TITLE
changed round to square brackets in pK2(Cai&Wang) + verified all calcs (K1, K2, fH, pHnbs2sws, pHsws2nbs)

### DIFF
--- a/R/K2.R
+++ b/R/K2.R
@@ -142,7 +142,7 @@ function(S=35,T=25,P=0,k1k2='x',pHscale="T",kSWS2scale="x",ktotal2SWS_P0="x",war
     #   pH-scale: 'total'. mol/kg-soln
     is_cw <- k1k2 == "cw"	
     F2  <- -129.24/TK[is_cw] + 1.4381
-    pK2[is_cw] <- 2902.39/TK[is_cw] + 0.02379*TK(is_cw) - 6.4980 - 0.3191*F2*S[is_cw]^0.5 + 0.0198*S[is_cw]
+    pK2[is_cw] <- 2902.39/TK[is_cw] + 0.02379*TK[is_cw] - 6.4980 - 0.3191*F2*S[is_cw]^0.5 + 0.0198*S[is_cw]
     K2[is_cw] <- 10.0^(-pK2)         # this is on the NBS scale
     # Convert from NBS to SWS scale using combined activity coefficient fH 
     # Takahashi (1982, GEOSECS Pacific Expedition, Chap 3, p. 80), who say:


### PR DESCRIPTION
Fixed bug in the new K2.R function where in one instance parentheses were used instead of square brackets in the pK2 formulation for Cai & Wang (1998).

I have also compared the results of K1, K2, fH between seacarb and CO2SYS-MATLAB. They are identical.

Likewise, I have verified that pHnbs2sws.R and pHsws2nbs.R give identical answers to what is found internaly in CO2SYS-MATLAB (the CO2SYS.m routine).

All checks perfectly, and we are ready to go. So I think you can now create a new official version of seacarb for Ray and others interested in using pHNBS or the Cai & Wang (1998) K1 and K2 constants.  Then we can formally close that request.

Thanks!